### PR TITLE
Refactor code into multiple classes (part 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build/*.py
 build/compile/*
 flash-patcher.zip
+flash-patcher

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .Patcher-Temp/* 
+*/__pycache__/*
+build/*.py
+build/compile/*
+flash-patcher.zip

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-install-lite:
-	sudo cp flash-patcher.py /usr/local/bin
-	sudo mv /usr/local/bin/flash-patcher.py /usr/local/bin/flash-patcher
-
-install:
-	sudo cp flash-patcher.py /usr/local/bin
-	sudo mv /usr/local/bin/flash-patcher.py /usr/local/bin/flash-patcher
-	sudo cp flash-patcher.json /var/gh-update/flash-patcher.json

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ To apply a patch, run the following command:
 
 The patcher will take the input SWF, apply the patches specified in the stage file (which must be located in the patch folder), and create the output SWF.
 
-You can also install Flash Patcher by running `sudo make install`. After this, you can run Flash Patcher with `flash-patcher [args]`.
+You can also install Flash Patcher by running `cd build && sudo make install`. After this, you can run Flash Patcher with `flash-patcher [args]`.
 
-To install without automatic updates, you can run `sudo make install-lite` instead.
+To install without automatic updates, you can run `cd build && sudo make install-lite` instead.
 
 The command line arguments are as follows:
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,0 +1,15 @@
+# How to package and run multiple Python files:
+# https://stackoverflow.com/questions/9002275/how-to-build-a-single-python-file-from-multiple-scripts
+
+bundle:
+	cp -r ../src/__main__.py ../src/patcher.py ../src/compile/ .
+	zip -r -D ../flash-patcher.zip .
+	echo "#!/usr/bin/python3" | /usr/bin/cat - ../flash-patcher.zip > ../flash-patcher
+	chmod +x ../flash-patcher
+
+install-lite: bundle
+	sudo cp ../flash-patcher /usr/local/bin
+
+install: bundle
+	sudo cp ../flash-patcher /usr/local/bin
+	sudo cp ../flash-patcher.json /var/gh-update/flash-patcher.json

--- a/flash-patcher.json
+++ b/flash-patcher.json
@@ -1,12 +1,11 @@
 {
     "local": {
-        "version": "4.1.5",
-
+        "version": "4.1.6",
         "location": "/usr/local/bin/flash-patcher"
     },
 
     "remote": {
         "url": "/rayyaw/flash-patcher",
-        "assetName": "flash-patcher.py"
+        "assetName": "flash-patcher.zip"
     }
 }

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+
+from patcher import main
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--inputswf",
+        dest="input_swf",
+        type=str,
+        required=True,
+        help="Input SWF file",
+    )
+
+    parser.add_argument(
+        "--folder",
+        dest="folder",
+        type=str,
+        required=True,
+        help="Folder with patch files",
+    )
+
+    parser.add_argument(
+        "--stagefile",
+        dest="stage_file",
+        type=str,
+        required=True,
+        help="Stage file name",
+    )
+
+    parser.add_argument(
+        "--outputswf",
+        dest="output_swf",
+        type=str,
+        required=True,
+        help="Output SWF file",
+    )
+
+    parser.add_argument(
+        "--invalidateCache",
+        dest="drop_cache",
+        default=False,
+        action="store_true",
+        help="Invalidate cached decompilation files",
+    )
+
+    parser.add_argument(
+        "--all",
+        dest="recompile_all",
+        default=False,
+        action="store_true",
+        help="Recompile the whole SWF (if this is off, only scripts will recompile)",
+    )
+
+    parser.add_argument(
+        "--xml",
+        dest="xml_mode",
+        default=False,
+        action="store_true",
+        help="Inject into an XML decompilation instead of standard syntax",
+    )
+
+    args = parser.parse_args()
+
+    main(
+        Path(args.input_swf),
+        Path(args.folder),
+        Path(args.stage_file),
+        Path(args.output_swf),
+        drop_cache=args.drop_cache,
+        recompile_all=args.recompile_all,
+        xml_mode=args.xml_mode,
+    )

--- a/src/compile/__init__.py
+++ b/src/compile/__init__.py
@@ -1,0 +1,1 @@
+# empty file, only needed for the zip to detect this folder

--- a/src/compile/compilation.py
+++ b/src/compile/compilation.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import base64
+import sys
+from logging import error, info
+from pathlib import Path
+
+from .jpexs import JPEXSInterface
+
+class CompilationManager:
+    """Manage Flash compilation and decompilation, including caching.
+    This class should not call JPEXS directly, instead it should use the JPEXSInterface."""
+
+    decompiler: JPEXSInterface
+
+    def __init__(self: CompilationManager) -> None:
+        self.decompiler = JPEXSInterface()
+
+    def decompile(
+        self: CompilationManager,
+        inputfile: Path,
+        drop_cache: bool = False, 
+        xml_mode: bool = False
+    ) -> Path:
+        """Decompile the SWF and return the decompilation location.
+
+        This uses caching to save time.
+
+        inputfile: the SWF to decompile
+        drop_cache: if True, will force decompilation instead of using cached files
+        xml_mode: if True, will dump XML instead of decompiling normally
+        """
+        # Validity checking: Decompilation path and input file
+        if not Path("./.Patcher-Temp").exists():
+            Path("./.Patcher-Temp").mkdir()
+
+        if not inputfile.exists():
+            error(
+                """Could not locate the SWF file: %s.
+                Aborting...""",
+                inputfile,
+            )
+            sys.exit(1)
+
+        # Decompile swf into temp folder called ./.Patcher-Temp/[swf name, base32 encoded]
+        cache_location = Path(
+            "./.Patcher-Temp/",
+            base64.b32encode(
+                bytes(inputfile.name, "utf-8"),
+            ).decode("ascii"),
+        )
+
+        # If the cache is dropped or nonexistent, rerun decompiler
+        if drop_cache or (not Path(cache_location).exists()):
+            if not Path(cache_location).exists() and not xml_mode:
+                Path(cache_location).mkdir()
+
+            info("Beginning decompilation...")
+
+            decomp = None
+
+            if xml_mode:
+                decomp = self.decompiler.dump_xml(inputfile, cache_location)
+                info("XML decompilation mode.")
+            else:
+                decomp = self.decompiler.export_scripts(inputfile, cache_location)
+
+            if not decomp:
+                error(
+                    """JPEXS couldn't decompile the SWF file: %s.
+                    Aborting...""",
+                    inputfile,
+                )
+                sys.exit(1)
+
+        else:
+            info("Detected cached decompilation. Skipping...")
+
+        return cache_location
+    
+    def recompile(
+        self: CompilationManager,
+        injection: Path,
+        inputfile: Path,
+        output: Path,
+        recompile_all: bool = False,
+        xml_mode: bool = False,
+    ) -> None:
+        """Recompile the SWF after injection is complete.
+
+        inputfile: The base SWF to use for missing files
+        outputfile: The location to save the output
+        recompile_all: If this is set to False, will only recompile scripts
+        """
+        # Repackage the file as a SWF
+        # Rant: JPEXS should really return an error code if recompilation fails here!
+        # Unable to detect if this was successful or not otherwise.
+        if xml_mode:
+            self.decompiler.rebuild_xml(injection, output)
+            return
+
+        self.decompiler.recompile_data("Script", injection, inputfile, output)
+
+        if recompile_all:
+            for part in ("Images", "Sounds", "Shapes", "Text"):
+                # JPEXS doesn't have a way to import everything at once.
+                # We re-import iteratively.
+                self.decompiler.recompile_data(part, injection, output, output)

--- a/src/compile/jpexs.py
+++ b/src/compile/jpexs.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from logging import info
+from pathlib import Path
+
+LOCATION_APT = Path("/usr/bin/ffdec")
+LOCATION_FLATPAK = Path("/usr/bin/flatpak")
+LOCATION_WINDOWS = Path(f"{os.getenv('PROGRAMFILES')}\\FFDec\\ffdec.bat")
+LOCATION_WOW64 = Path(f"{os.getenv('PROGRAMFILES(X86)')}\\FFDec\\ffdec.bat")
+
+ARGS_FLATPAK = [
+    "run",
+    "--branch=stable",
+    "--arch=x86_64",
+    "--command=ffdec.sh",
+    "com.jpexs.decompiler.flash",
+]
+
+class JPEXSInterface:
+    """An interface to interact with JPEXS via the shell.
+    This class should only be used for functions that have a one-to-one correspondence
+    with JPEXS CLI commands.
+    For anything more sophisticated, you should use the CompilationManager class instead."""
+
+    path: Path
+    args: list
+
+    def __init__(self: JPEXSInterface, path: Path | None = None, args: list | None = None) -> None:
+        """Initialize by detecting JPEXS, or using a provided version"""
+        if path is not None:
+            self.path = path
+            if args is None:
+                self.args = []
+            else:
+                self.args = args
+
+            info("Using JPEXS at: %s", path)
+
+        else:
+            # Auto-detect JPEXS at any of the default locations
+            jpexs_installed = any([
+                self.install_jpexs(LOCATION_APT),
+                self.install_jpexs(LOCATION_FLATPAK, ARGS_FLATPAK),
+                self.install_jpexs(LOCATION_WINDOWS),
+                self.install_jpexs(LOCATION_WOW64),
+            ])
+            
+            if not jpexs_installed:
+                raise ModuleNotFoundError("Failed to locate dependency: JPEXS Flash Decompiler") 
+
+            info("Using JPEXS at: %s", self.path) 
+
+    def install_jpexs(self, path: Path, args: list | None = None) -> bool:
+        """Install JPEXS from a path. Return true if the installation was successful."""
+        if path.exists() and args is None:
+            # Normal JPEXS install, we're just running ffdec.sh directly
+            self.path = path
+            return True
+        elif path.exists():
+            # We're running JPEXS through a sandbox or proxy (like Flatpak)
+            # path.exists() checks that the path exists, but not that JPEXS is installed
+            # so we need to run jpexs -help to verify it's installed correctly
+            testrun = subprocess.run(
+                    [path, *args, "-help"],
+                    stdout=subprocess.DEVNULL,
+                    check=True,
+                )
+
+            if testrun.returncode == 0:
+                self.path = path
+                self.args = args
+                return True
+            
+        return False
+
+    def dump_xml(
+        self: JPEXSInterface,
+        inputfile: Path,
+        output_dir: Path,
+    ) -> bool:
+        """Dump XML data of the input file into the output location.
+        Returns True if dump was successful."""
+        process =  subprocess.run(
+            [self.path, *self.args, "-swf2xml", inputfile, output_dir],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+        return process.returncode == 0
+
+    def rebuild_xml(
+        self: JPEXSInterface,
+        input_dir: Path,
+        output_file: Path,
+    ) -> bool:
+        """Rebuild XML data from a directory into an output SWF file.
+        Return True on success."""
+        process = subprocess.run(
+            [self.path, *self.args, "-xml2swf", input_dir, output_file],
+            stdout=subprocess.DEVNULL,
+            check=True,
+        )
+        return process.returncode == 0
+
+    def export_scripts(
+        self: JPEXSInterface,
+        inputfile: Path,
+        output_dir: Path,
+    ) -> bool:
+        """Export scripts from a SWF file into a directory.
+        Returns True on success."""
+        info("Exporting scripts into %s...", output_dir)
+        process = subprocess.run(
+            [
+                self.path,
+                *self.args,
+                "-export",
+                "script",
+                output_dir,
+                inputfile,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+
+        return process.returncode == 0
+
+    def recompile_data(
+        self: JPEXSInterface,
+        part: str,
+        decomp_location: Path,
+        swf: Path,
+        output: Path,
+    ) -> int:
+        """Recompile data of a given type into the SWF file."""
+        # Part types: SymbolClass, Movies, Sounds, Shapes, Images, Text, Script
+        info("Reimporting %s...", part)
+        return subprocess.run(
+            [
+                self.path,
+                *self.args,
+                f"-import{part}",
+                swf,
+                output,
+                decomp_location,
+            ],
+            stdout=subprocess.DEVNULL,
+            check=True,
+        )

--- a/src/compile/jpexs.py
+++ b/src/compile/jpexs.py
@@ -57,6 +57,7 @@ class JPEXSInterface:
         if path.exists() and args is None:
             # Normal JPEXS install, we're just running ffdec.sh directly
             self.path = path
+            self.args = []
             return True
         elif path.exists():
             # We're running JPEXS through a sandbox or proxy (like Flatpak)


### PR DESCRIPTION
## Changes

- Refactoring code into multiple files (part 1): All compilation/decompilation logic is now in separate classes and files.
- Update build script to use .zip, which supports multiple Python files.

## Testing
- Ran SMF hacks to verify everything looked good

## Associated issues
- https://github.com/rayyaw/flash-patcher/issues/25