### PR TITLE
Fix decompilation issues

### DIFF
--- a/src/compile/jpexs.py
+++ b/src/compile/jpexs.py
@@ -132,13 +132,13 @@ class JPEXSInterface:
             [
                 self.path,
                 *self.args,
+		"-config",
+		"autoDeobfuscate=1,parallelSpeedUp=0",
                 "-export",
                 "script",
                 output_dir,
                 inputfile,
             ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
             check=False,
         )
 

--- a/src/compile/jpexs.py
+++ b/src/compile/jpexs.py
@@ -139,6 +139,8 @@ class JPEXSInterface:
                 output_dir,
                 inputfile,
             ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
             check=False,
         )
 

--- a/test/compile/test_jpexs.py
+++ b/test/compile/test_jpexs.py
@@ -181,6 +181,8 @@ class JPEXSInterfaceSpec (TestCase):
         mock_subprocess_run.assert_called_once_with([
             '/usr/bin/ffdec',
             '--derppotato',
+            '-config',
+            'autoDeobfuscate=1,parallelSpeedUp=0',
             '-export',
             'script',
             output,
@@ -203,6 +205,8 @@ class JPEXSInterfaceSpec (TestCase):
         mock_subprocess_run.assert_called_once_with([
             '/usr/bin/ffdec',
             '--derppotato',
+            '-config',
+            'autoDeobfuscate=1,parallelSpeedUp=0',
             '-export',
             'script',
             output,


### PR DESCRIPTION
Enables automatic deobfuscation and disables parallel speedup. This prevents a stack overflow that messes with frame_5.as in Super Mario 63.