### PR TITLE
Integration tests

### DIFF
--- a/.github/common-setup.sh
+++ b/.github/common-setup.sh
@@ -1,8 +1,4 @@
 # Common setup for all GitHub workflows of Flash Patcher
-echo -e "\nInstalling Java..."
-wget https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.deb
-sudo apt install ./jdk-17_linux-x64_bin.deb
-
 echo -e "\nInstalling JPEXS..."
 wget https://github.com/jindrapetrik/jpexs-decompiler/releases/download/version20.0.0/ffdec_20.0.0.deb
 sudo apt install ./ffdec_20.0.0.deb

--- a/.github/common-setup.sh
+++ b/.github/common-setup.sh
@@ -1,8 +1,5 @@
 # Common setup for all GitHub workflows of Flash Patcher
 
-echo -e "\nInstalling Java..."
-sudo apt install default-jdk
-
 echo -e "\nInstalling JPEXS..."
 wget https://github.com/jindrapetrik/jpexs-decompiler/releases/download/version20.0.0/ffdec_20.0.0.deb
 sudo apt install ./ffdec_20.0.0.deb

--- a/.github/common-setup.sh
+++ b/.github/common-setup.sh
@@ -1,4 +1,6 @@
 # Common setup for all GitHub workflows of Flash Patcher
+echo -e "\nInstalling Java..."
+sudo apt install default-jdk
 
 echo -e "\nInstalling JPEXS..."
 wget https://github.com/jindrapetrik/jpexs-decompiler/releases/download/version20.0.0/ffdec_20.0.0.deb

--- a/.github/common-setup.sh
+++ b/.github/common-setup.sh
@@ -3,15 +3,15 @@
 echo -e "\nInstalling Java..."
 sudo apt install default-jdk
 
-echo -e "\nInstalling Mock JPEXS..."
-sudo touch /usr/bin/ffdec
+echo -e "\nInstalling JPEXS..."
+wget https://github.com/jindrapetrik/jpexs-decompiler/releases/download/version20.0.0/ffdec_20.0.0.deb
+sudo apt install ffdec_20.0.0.deb
 
 echo -e "\nInstalling ANTLR..."
 wget https://www.antlr.org/download/antlr-4.13.1-complete.jar
 echo 'export CLASSPATH=".:$GITHUB_WORKSPACE/antlr-4.13.1-complete.jar:$CLASSPATH"' >> $GITHUB_ENV
 
 echo -e "\nInstalling pip dependencies..."
-python -m pip install --upgrade pip
 python -m pip install -U pytest
 pip install antlr4-python3-runtime pylint coverage
 

--- a/.github/common-setup.sh
+++ b/.github/common-setup.sh
@@ -1,6 +1,6 @@
 # Common setup for all GitHub workflows of Flash Patcher
 echo -e "\nInstalling Java..."
-sudo apt install default-jdk
+sudo apt install default-jre
 
 echo -e "\nInstalling JPEXS..."
 wget https://github.com/jindrapetrik/jpexs-decompiler/releases/download/version20.0.0/ffdec_20.0.0.deb

--- a/.github/common-setup.sh
+++ b/.github/common-setup.sh
@@ -12,8 +12,8 @@ wget https://www.antlr.org/download/antlr-4.13.1-complete.jar
 echo 'export CLASSPATH=".:$GITHUB_WORKSPACE/antlr-4.13.1-complete.jar:$CLASSPATH"' >> $GITHUB_ENV
 
 echo -e "\nInstalling pip dependencies..."
-python -m pip install -U pytest
-pip install antlr4-python3-runtime pylint coverage
+python3 -m pip install -U pytest
+python3 -m pip install antlr4-python3-runtime pylint coverage
 
 echo -e "\nBuilding ANTLR files..."
 cd build && make antlr-java

--- a/.github/common-setup.sh
+++ b/.github/common-setup.sh
@@ -5,7 +5,7 @@ sudo apt install default-jdk
 
 echo -e "\nInstalling JPEXS..."
 wget https://github.com/jindrapetrik/jpexs-decompiler/releases/download/version20.0.0/ffdec_20.0.0.deb
-sudo apt install ffdec_20.0.0.deb
+sudo apt install ./ffdec_20.0.0.deb
 
 echo -e "\nInstalling ANTLR..."
 wget https://www.antlr.org/download/antlr-4.13.1-complete.jar

--- a/.github/common-setup.sh
+++ b/.github/common-setup.sh
@@ -1,6 +1,7 @@
 # Common setup for all GitHub workflows of Flash Patcher
 echo -e "\nInstalling Java..."
-sudo apt install default-jre
+wget https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.deb
+sudo apt install ./jdk-17_linux-x64_bin.deb
 
 echo -e "\nInstalling JPEXS..."
 wget https://github.com/jindrapetrik/jpexs-decompiler/releases/download/version20.0.0/ffdec_20.0.0.deb

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -1,6 +1,6 @@
 name: Integration Tests
 
-on: [push, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -24,6 +24,7 @@ jobs:
         cd ..
     - name: Install test library
       run: |
+        ls /usr/local/bin
         git clone https://github.com/rayyaw/flash-patcher-tests.git
         export PATH="/usr/local/bin:$PATH"
     - name: Run integration tests

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -14,6 +14,11 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Set up Java
+      uses: actions/setup-java@v4.0.0
+      with:
+        distribution: 'adopt'
+        java-version: '17'
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -28,5 +28,4 @@ jobs:
     - name: Run integration tests
       run: |
         cd flash-patcher-tests
-        ls
         ./run-all-tests.sh

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -20,6 +20,7 @@ jobs:
     - name: Install Flash Patcher
       run: |
         cd build
+        export ANTLR_TARGET=antlr-java
         make
         cd ..
     - name: Install test library

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -25,7 +25,6 @@ jobs:
         cd ..
     - name: Install test library
       run: |
-        ls /usr/local/bin
         git clone https://github.com/rayyaw/flash-patcher-tests.git
     - name: Run integration tests
       run: |

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/setup-java@v4.0.0
       with:
         distribution: 'adopt'
-        java-version: '17'
+        java-version: '11'
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Install test library
       run:
         git clone https://github.com/rayyaw/flash-patcher-tests.git
+        export PATH="/usr/local/bin:$PATH"
     - name: Run integration tests
       run: |
         cd flash-patcher-tests

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -14,11 +14,11 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    # - name: Set up Java
-    #   uses: actions/setup-java@v4.0.0
-    #   with:
-    #     distribution: 'adopt'
-    #     java-version: '17'
+    - name: Set up Java
+      uses: actions/setup-java@v4.0.0
+      with:
+        distribution: 'adopt'
+        java-version: '17'
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/setup-java@v4.0.0
       with:
         distribution: 'adopt'
-        java-version: '11'
+        java-version: '17'
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -26,6 +26,6 @@ jobs:
       run:
         git clone https://github.com/rayyaw/flash-patcher-tests.git
     - name: Run integration tests
-      run:
+      run: |
         cd flash-patcher-tests
         ./run-all-tests.sh

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -14,11 +14,11 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    #- name: Set up Java
-    #  uses: actions/setup-java@v4.0.0
-    #  with:
-    #    distribution: 'adopt'
-    #    java-version: '17'
+    # - name: Set up Java
+    #   uses: actions/setup-java@v4.0.0
+    #   with:
+    #     distribution: 'adopt'
+    #     java-version: '17'
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -23,7 +23,7 @@ jobs:
         make && sudo make install
         cd ..
     - name: Install test library
-      run:
+      run: |
         git clone https://github.com/rayyaw/flash-patcher-tests.git
         export PATH="/usr/local/bin:$PATH"
     - name: Run integration tests

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         source .github/common-setup.sh
     - name: Install Flash Patcher
-      run:
+      run: |
         cd build
         make && sudo make install
         cd ..

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -28,4 +28,5 @@ jobs:
     - name: Run integration tests
       run: |
         cd flash-patcher-tests
+        ls
         ./run-all-tests.sh

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -21,13 +21,12 @@ jobs:
       run: |
         cd build
         export ANTLR_TARGET=antlr-java
-        make
+        make && sudo make install
         cd ..
     - name: Install test library
       run: |
         ls /usr/local/bin
         git clone https://github.com/rayyaw/flash-patcher-tests.git
-        export PATH="$GITHUB_WORKSPACE:$PATH"
     - name: Run integration tests
       run: |
         cd flash-patcher-tests

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -20,13 +20,13 @@ jobs:
     - name: Install Flash Patcher
       run: |
         cd build
-        make && sudo make install
+        make
         cd ..
     - name: Install test library
       run: |
         ls /usr/local/bin
         git clone https://github.com/rayyaw/flash-patcher-tests.git
-        export PATH="/usr/local/bin:$PATH"
+        export PATH="$GITHUB_WORKSPACE:$PATH"
     - name: Run integration tests
       run: |
         cd flash-patcher-tests

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         cd build
         export ANTLR_TARGET=antlr-java
-        make && sudo make install
+        make && sudo make install-lite
         cd ..
     - name: Install test library
       run: |

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -1,0 +1,31 @@
+name: Integration Tests
+
+on: [push, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Common Dependencies
+      run: |
+        source .github/common-setup.sh
+    - name: Install Flash Patcher
+      run:
+        cd build
+        make && sudo make install
+        cd ..
+    - name: Install test library
+      run:
+        git clone https://github.com/rayyaw/flash-patcher-tests.git
+    - name: Run integration tests
+      run:
+        cd flash-patcher-tests
+        ./run-all-tests.sh

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -14,11 +14,11 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Set up Java
-      uses: actions/setup-java@v4.0.0
-      with:
-        distribution: 'adopt'
-        java-version: '17'
+    #- name: Set up Java
+    #  uses: actions/setup-java@v4.0.0
+    #  with:
+    #    distribution: 'adopt'
+    #    java-version: '17'
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -14,6 +14,11 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Set up Java
+      uses: actions/setup-java@v4.0.0
+      with:
+        distribution: 'adopt'
+        java-version: '17'
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/setup-java@v4.0.0
       with:
         distribution: 'adopt'
-        java-version: '17'
+        java-version: '11'
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -14,11 +14,11 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Set up Java
-      uses: actions/setup-java@v4.0.0
-      with:
-        distribution: 'adopt'
-        java-version: '17'
+    # - name: Set up Java
+    #   uses: actions/setup-java@v4.0.0
+    #   with:
+    #     distribution: 'adopt'
+    #     java-version: '17'
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -14,11 +14,11 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    # - name: Set up Java
-    #   uses: actions/setup-java@v4.0.0
-    #   with:
-    #     distribution: 'adopt'
-    #     java-version: '17'
+    - name: Set up Java
+      uses: actions/setup-java@v4.0.0
+      with:
+        distribution: 'adopt'
+        java-version: '17'
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/setup-java@v4.0.0
       with:
         distribution: 'adopt'
-        java-version: '11'
+        java-version: '17'
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -14,6 +14,11 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Set up Java
+      uses: actions/setup-java@v4.0.0
+      with:
+        distribution: 'adopt'
+        java-version: '17'
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/setup-java@v4.0.0
       with:
         distribution: 'adopt'
-        java-version: '17'
+        java-version: '11'
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -14,11 +14,11 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Set up Java
-      uses: actions/setup-java@v4.0.0
-      with:
-        distribution: 'adopt'
-        java-version: '17'
+    # - name: Set up Java
+    #   uses: actions/setup-java@v4.0.0
+    #   with:
+    #     distribution: 'adopt'
+    #     java-version: '17'
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -14,11 +14,11 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    # - name: Set up Java
-    #   uses: actions/setup-java@v4.0.0
-    #   with:
-    #     distribution: 'adopt'
-    #     java-version: '17'
+    - name: Set up Java
+      uses: actions/setup-java@v4.0.0
+      with:
+        distribution: 'adopt'
+        java-version: '17'
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/setup-java@v4.0.0
       with:
         distribution: 'adopt'
-        java-version: '11'
+        java-version: '17'
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh

--- a/build/Makefile
+++ b/build/Makefile
@@ -10,7 +10,7 @@ all: $(ANTLR_TARGET)
 	cp -r ../src/* .
 	find . -type d -exec touch {}/__init__.py \;
 	zip -r -D ../flash-patcher.zip . > /dev/null
-	echo "#!/usr/bin/python3" | /usr/bin/cat - ../flash-patcher.zip > ../flash-patcher
+	echo "#!/usr/bin/env python3" | /usr/bin/cat - ../flash-patcher.zip > ../flash-patcher
 	chmod +x ../flash-patcher
 
 # Move stuff to antlr-source in preparation for compilation

--- a/src/compile/jpexs.py
+++ b/src/compile/jpexs.py
@@ -73,6 +73,7 @@ class JPEXSInterface:
             testrun = subprocess.run(
                 [path, *args, "-help"],
                 stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
                 check=False,
             )
 

--- a/src/inject/injection_location.py
+++ b/src/inject/injection_location.py
@@ -54,7 +54,7 @@ class InjectionLocation:
         """Resolve the injection location if it's a line number."""
         if self.line_no > len(file_content):
             exception.raise_(
-                """Out of bounds add location.
+                f"""Out of bounds add location {self.symbolic_location}.
                 The provided location is outside the maximum line number in the file."""
             )
 

--- a/src/inject/single_injection.py
+++ b/src/inject/single_injection.py
@@ -43,7 +43,7 @@ class SingleInjectionManager:
     def inject(self: SingleInjectionManager, content: list[str], patch_file_line: int) -> None:
         """Inject the content into the file."""
         patch_line_no = patch_file_line
-        file_line_no = self.file_location.resolve(self.file_content, self.patch_line_no)
+        file_line_no = self.file_location.resolve(self.file_content, self.error_manager)
 
         for line in content:
             line_stripped = line.strip("\n\r ")


### PR DESCRIPTION
## Changes
- Add an integration test workflow.
- This currently only supports SMF.
- You can find the integration tests here: https://github.com/rayyaw/flash-patcher-tests (kept separate since these will contain a static snapshot of some downstream users)
- Switch to `#!/usr/bin/env python3` instead of `#!/usr/bin/python3` since the latter breaks the GitHub Actions workflow and may not always work
- All workflows now setup Java with a GitHub workflow rather than doing so manually.

## Testing
- Unit tests
- Integration tests
- Ran on the SMF hacks manually to verify everything looked good.

## Related issues and milestones
- This is the final PR before we migrate to pip :D 
- closes https://github.com/rayyaw/flash-patcher/issues/44

## Requested work from reviewer
Please perform the following tasks:
- Create a PR to use SM63 in the integration tests repo. You can use the existing boilerplate code for SMF. You should only need to update `run-all-tests.sh` and the `build.sh` in the SM63 directory.
- Rerun the workflow using SM63 to make sure this works as well.