### PR TITLE
Rename all instances of JPEXS to FFDec

### DIFF
--- a/.github/common-setup.sh
+++ b/.github/common-setup.sh
@@ -1,5 +1,5 @@
 # Common setup for all GitHub workflows of Flash Patcher
-echo -e "\nInstalling JPEXS..."
+echo -e "\nInstalling FFDec..."
 wget https://github.com/jindrapetrik/jpexs-decompiler/releases/download/version20.0.0/ffdec_20.0.0.deb
 sudo apt install ./ffdec_20.0.0.deb
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You must have `gh-update` installed to receive automatic updates. For more info,
 
 You must install JPEXS Free Flash Decompiler to use this patcher. For more information, check https://github.com/jindrapetrik/jpexs-decompiler.
 
-Flash Patcher will automatically detect your JPEXS install location.
+Flash Patcher will automatically detect your FFDec install location.
 
 You must have Python 3.10 or greater on your system to run this script, including the `antlr4-python3-runtime` pip package.
 
@@ -85,7 +85,7 @@ end-patch
 remove frame_1/DoAction.as 789-1111
 ```
 
-You can use \# to write comments. There are two types of commands, `add` and `remove`. The first parameter to any command is the file to modify (in this case, "DefineSprite_1058 boss2/DoAction.as" or "frame_1/DoAction.as"). To find the name of this, export all scripts using JPEXS and make a note of the file name you want to modify.
+You can use \# to write comments. There are two types of commands, `add` and `remove`. The first parameter to any command is the file to modify (in this case, "DefineSprite_1058 boss2/DoAction.as" or "frame_1/DoAction.as"). To find the name of this, export all scripts using FFDec and make a note of the file name you want to modify.
 
 You are allowed to put multiple `add` statements before a code block you wish to inject.
 

--- a/src/compile/compilation.py
+++ b/src/compile/compilation.py
@@ -4,19 +4,19 @@ import base64
 from logging import error, info
 from pathlib import Path
 
-from compile.jpexs import JPEXSInterface
+from src.compile.ffdec import FFDecInterface
 from exception_handle.dependency import DependencyError
 
 class CompilationManager:
     """Manage Flash compilation and decompilation, including caching.
 
-    This class should not call JPEXS directly, instead it should use the JPEXSInterface.
+    This class should not call FFDec directly, instead it should use the FFDecInterface.
     """
 
-    decompiler: JPEXSInterface
+    decompiler: FFDecInterface
 
     def __init__(self: CompilationManager) -> None:
-        self.decompiler = JPEXSInterface()
+        self.decompiler = FFDecInterface()
 
     def decompile(
         self: CompilationManager,
@@ -67,7 +67,7 @@ class CompilationManager:
                 decomp = self.decompiler.export_scripts(inputfile, cache_location)
 
             if not decomp:
-                failure_mesg = f"""JPEXS couldn't decompile the SWF file: {inputfile}.
+                failure_mesg = f"""FFDec couldn't decompile the SWF file: {inputfile}.
                     Aborting..."""
 
                 error(failure_mesg)
@@ -89,7 +89,7 @@ class CompilationManager:
         recomp = self.decompiler.recompile_data(part, decomp_location, swf, output)
 
         if not recomp:
-            failure_mesg = f"""JPEXS couldn't recompile the SWF file: {swf}.
+            failure_mesg = f"""FFDec couldn't recompile the SWF file: {swf}.
                 Aborting.."""
 
             error(failure_mesg)
@@ -117,6 +117,6 @@ class CompilationManager:
 
         if recompile_all:
             for part in ("Images", "Sounds", "Shapes", "Text"):
-                # JPEXS doesn't have a way to import everything at once.
+                # FFDec doesn't have a way to import everything at once.
                 # We re-import iteratively.
                 self.recompile_with_check(part, injection, output, output)

--- a/src/compile/compilation.py
+++ b/src/compile/compilation.py
@@ -4,7 +4,7 @@ import base64
 from logging import error, info
 from pathlib import Path
 
-from src.compile.ffdec import FFDecInterface
+from compile.ffdec import FFDecInterface
 from exception_handle.dependency import DependencyError
 
 class CompilationManager:

--- a/src/compile/ffdec.py
+++ b/src/compile/ffdec.py
@@ -18,11 +18,11 @@ ARGS_FLATPAK = [
     "com.jpexs.decompiler.flash",
 ]
 
-class JPEXSInterface:
-    """An interface to interact with JPEXS via the shell.
+class FFDecInterface:
+    """An interface to interact with FFDec via the shell.
 
     This class should only be used for functions that have a one-to-one correspondence
-    with JPEXS CLI commands.
+    with FFDec CLI commands.
     For anything more sophisticated, you should use the CompilationManager class instead.
     """
 
@@ -30,11 +30,11 @@ class JPEXSInterface:
     args: list[str]
 
     def __init__(
-        self: JPEXSInterface,
+        self: FFDecInterface,
         path: Path | None = None,
         args: list[str] | None = None,
     ) -> None:
-        """Initialize by detecting JPEXS, or using a provided version"""
+        """Initialize by detecting FFDec, or using a provided version"""
         if path is not None:
             self.path = path
             if args is None:
@@ -42,34 +42,34 @@ class JPEXSInterface:
             else:
                 self.args = args
 
-            info("Using JPEXS at: %s", path)
+            info("Using FFDec at: %s", path)
 
         else:
-            # Auto-detect JPEXS at any of the default locations
-            jpexs_installed = any([
-                self.install_jpexs(LOCATION_APT),
-                self.install_jpexs(LOCATION_FLATPAK, ARGS_FLATPAK),
-                self.install_jpexs(LOCATION_WINDOWS),
-                self.install_jpexs(LOCATION_WOW64),
+            # Auto-detect FFDec at any of the default locations
+            ffdec_installed = any([
+                self.install_ffdec(LOCATION_APT),
+                self.install_ffdec(LOCATION_FLATPAK, ARGS_FLATPAK),
+                self.install_ffdec(LOCATION_WINDOWS),
+                self.install_ffdec(LOCATION_WOW64),
             ])
 
-            if not jpexs_installed:
+            if not ffdec_installed:
                 raise ModuleNotFoundError("Failed to locate dependency: JPEXS Flash Decompiler")
 
-            info("Using JPEXS at: %s", self.path)
+            info("Using FFDec at: %s", self.path)
 
-    def install_jpexs(self :JPEXSInterface, path: Path, args: list[str] | None = None) -> bool:
-        """Install JPEXS from a path. Return true if the installation was successful."""
+    def install_ffdec(self: FFDecInterface, path: Path, args: list[str] | None = None) -> bool:
+        """Install FFDec from a path. Return true if the installation was successful."""
         if path.exists() and args is None:
-            # Normal JPEXS install, we're just running ffdec.sh directly
+            # Normal FFDec install, we're just running ffdec.sh directly
             self.path = path
             self.args = []
             return True
 
         if path.exists():
-            # We're running JPEXS through a sandbox or proxy (like Flatpak)
-            # path.exists() checks that the path exists, but not that JPEXS is installed
-            # so we need to run jpexs -help to verify it's installed correctly
+            # We're running FFDec through a sandbox or proxy (like Flatpak)
+            # path.exists() checks that the path exists, but not that FFDec is installed
+            # so we need to run ffdec -help to verify it's installed correctly
             testrun = subprocess.run(
                 [path, *args, "-help"],
                 stdout=subprocess.DEVNULL,
@@ -85,7 +85,7 @@ class JPEXSInterface:
         return False
 
     def dump_xml(
-        self: JPEXSInterface,
+        self: FFDecInterface,
         inputfile: Path,
         output_dir: Path,
     ) -> bool:
@@ -102,7 +102,7 @@ class JPEXSInterface:
         return process.returncode == 0
 
     def rebuild_xml(
-        self: JPEXSInterface,
+        self: FFDecInterface,
         input_dir: Path,
         output_file: Path,
     ) -> bool:
@@ -118,7 +118,7 @@ class JPEXSInterface:
         return process.returncode == 0
 
     def export_scripts(
-        self: JPEXSInterface,
+        self: FFDecInterface,
         inputfile: Path,
         output_dir: Path,
     ) -> bool:
@@ -146,7 +146,7 @@ class JPEXSInterface:
         return process.returncode == 0
 
     def recompile_data(
-        self: JPEXSInterface,
+        self: FFDecInterface,
         part: str,
         decomp_location: Path,
         swf: Path,

--- a/test/compile/test_compilation.py
+++ b/test/compile/test_compilation.py
@@ -13,12 +13,12 @@ from pytest import raises
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../src')))
 
 from compile.compilation import CompilationManager
-from compile.jpexs import JPEXSInterface
+from compile.ffdec import FFDecInterface
 from exception_handle.dependency import DependencyError
 
 class CompilationManagerSpec (TestCase):
 
-    mock_decompiler: MagicMock[JPEXSInterface]
+    mock_decompiler: MagicMock[FFDecInterface]
     compilation_manager: CompilationManager
 
     swf: Path
@@ -28,9 +28,9 @@ class CompilationManagerSpec (TestCase):
     def __init__(self: CompilationManagerSpec, methodName: str = "runTest") -> None:
         super().__init__(methodName)
 
-        # Manual initialization required to mock the internal JPEXS interface
+        # Manual initialization required to mock the internal FFDec interface
         self.compilation_manager = CompilationManager()
-        self.mock_decompiler = MagicMock(spec=JPEXSInterface)
+        self.mock_decompiler = MagicMock(spec=FFDecInterface)
         self.compilation_manager.decompiler = self.mock_decompiler
 
         self.swf = Path("test.swf")
@@ -127,7 +127,7 @@ class CompilationManagerSpec (TestCase):
         self.mock_decompiler.assert_not_called()
 
     @patch('pathlib.Path.exists')
-    def test_decompile_failure_jpexs_error(
+    def test_decompile_failure_FFDec_error(
         self: CompilationManagerSpec,
         mock_path_exists: MagicMock,
     ) -> None:

--- a/test/compile/test_compilation.py
+++ b/test/compile/test_compilation.py
@@ -127,7 +127,7 @@ class CompilationManagerSpec (TestCase):
         self.mock_decompiler.assert_not_called()
 
     @patch('pathlib.Path.exists')
-    def test_decompile_failure_FFDec_error(
+    def test_decompile_failure_ffdec_error(
         self: CompilationManagerSpec,
         mock_path_exists: MagicMock,
     ) -> None:

--- a/test/compile/test_ffdec.py
+++ b/test/compile/test_ffdec.py
@@ -12,33 +12,33 @@ from pytest import raises
 # Not doing this causes import errors
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../src')))
 
-from compile.jpexs import JPEXSInterface
+from compile.ffdec import FFDecInterface
 
-class JPEXSInterfaceSpec (TestCase):
+class FFDecInterfaceSpec (TestCase):
 
     ffdec_path             : Path
-    interface              : JPEXSInterface
+    interface              : FFDecInterface
     subprocess_mock_success: MagicMock
     subprocess_mock_failure: MagicMock
 
-    def __init__(self: JPEXSInterfaceSpec, methodName: str = "runTest") -> None:
+    def __init__(self: FFDecInterfaceSpec, methodName: str = "runTest") -> None:
         super().__init__(methodName)
 
         # Manual initialization required for the default test case
         self.ffdec_path = Path("/usr/bin/ffdec")
-        self.interface = JPEXSInterface(self.ffdec_path, ["--derppotato"])
+        self.interface = FFDecInterface(self.ffdec_path, ["--derppotato"])
 
         self.subprocess_mock_success = MagicMock(returncode=0, stdout='', stderr='')
         self.subprocess_mock_failure = MagicMock(returncode=1, stdout='', stderr='Error!')
 
-    def test_sanity(self: JPEXSInterfaceSpec) -> None:
+    def test_sanity(self: FFDecInterfaceSpec) -> None:
         assert True
 
-    # JPEXS installation tests
+    # FFDec installation tests
     def test_automatic_installation_complete_success_manual(
-        self: JPEXSInterfaceSpec,
+        self: FFDecInterfaceSpec,
     ) -> None:
-        interface = JPEXSInterface(self.ffdec_path)
+        interface = FFDecInterface(self.ffdec_path)
 
         assert interface.path == self.ffdec_path
         assert interface.args == []
@@ -46,25 +46,25 @@ class JPEXSInterfaceSpec (TestCase):
         assert self.interface.path == self.ffdec_path
         assert self.interface.args == ["--derppotato"]
 
-    @patch('compile.jpexs.JPEXSInterface.install_jpexs')
+    @patch('compile.ffdec.FFDecInterface.install_ffdec')
     def test_automatic_installation_complete_failure_not_found(
-        self: JPEXSInterfaceSpec,
-        mock_install_jpexs: MagicMock
+        self: FFDecInterfaceSpec,
+        mock_install_FFDec: MagicMock
     ) -> None:
 
-        mock_install_jpexs.return_value = False
+        mock_install_FFDec.return_value = False
 
         with raises(ModuleNotFoundError):
-            JPEXSInterface()
+            FFDecInterface()
 
     @patch('pathlib.Path.exists')
     def test_automatic_installation_apt_success(
-        self: JPEXSInterfaceSpec,
+        self: FFDecInterfaceSpec,
         mock_path_exists: MagicMock
     ) -> None:
 
         mock_path_exists.return_value = True
-        success = self.interface.install_jpexs(self.ffdec_path)
+        success = self.interface.install_ffdec(self.ffdec_path)
 
         mock_path_exists.assert_called_once_with()
         assert self.interface.path == self.ffdec_path
@@ -73,12 +73,12 @@ class JPEXSInterfaceSpec (TestCase):
 
     @patch('pathlib.Path.exists')
     def test_automatic_installation_apt_failure(
-        self: JPEXSInterfaceSpec,
+        self: FFDecInterfaceSpec,
         mock_path_exists: MagicMock
     ) -> None:
 
         mock_path_exists.return_value = False
-        success = self.interface.install_jpexs(self.ffdec_path)
+        success = self.interface.install_ffdec(self.ffdec_path)
 
         assert mock_path_exists.call_count == 2
         assert not success
@@ -87,7 +87,7 @@ class JPEXSInterfaceSpec (TestCase):
     @patch('subprocess.run')
     # For whatever reason, the order of mocks is passed in reverse
     def test_automatic_installation_flatpak_success(
-        self: JPEXSInterfaceSpec,
+        self: FFDecInterfaceSpec,
         mock_subprocess_run: MagicMock,
         mock_path_exists: MagicMock,
     ) -> None:
@@ -95,7 +95,7 @@ class JPEXSInterfaceSpec (TestCase):
         mock_path_exists.return_value = True
         mock_subprocess_run.return_value = self.subprocess_mock_success
 
-        success = self.interface.install_jpexs(Path("/usr/bin/flatpak"), ["run", "--branch=stable"])
+        success = self.interface.install_ffdec(Path("/usr/bin/flatpak"), ["run", "--branch=stable"])
 
         assert mock_path_exists.call_count == 2
         assert self.interface.path == Path("/usr/bin/flatpak")
@@ -106,7 +106,7 @@ class JPEXSInterfaceSpec (TestCase):
     @patch('pathlib.Path.exists')
     @patch('subprocess.run')
     def test_automatic_installation_flatpak_failure(
-        self: JPEXSInterfaceSpec,
+        self: FFDecInterfaceSpec,
         mock_subprocess_run: MagicMock,
         mock_path_exists: MagicMock,
     ) -> None:
@@ -114,14 +114,14 @@ class JPEXSInterfaceSpec (TestCase):
         mock_path_exists.return_value = True
         mock_subprocess_run.return_value = self.subprocess_mock_failure
 
-        success = self.interface.install_jpexs(Path("/usr/bin/flatpak"), ["run", "--branch=stable"])
+        success = self.interface.install_ffdec(Path("/usr/bin/flatpak"), ["run", "--branch=stable"])
 
         assert mock_path_exists.call_count == 2
         assert not success
 
-    # JPEXS calling tests
+    # FFDec calling tests
     @patch('subprocess.run')
-    def test_dump_xml_success(self: JPEXSInterfaceSpec, mock_subprocess_run: MagicMock) -> None:
+    def test_dump_xml_success(self: FFDecInterfaceSpec, mock_subprocess_run: MagicMock) -> None:
         input_swf = Path("./.Patcher-Temp/base.swf")
         output = Path("./folder")
 
@@ -139,7 +139,7 @@ class JPEXSInterfaceSpec (TestCase):
         assert success
 
     @patch('subprocess.run')
-    def test_dump_xml_failure(self: JPEXSInterfaceSpec, mock_subprocess_run: MagicMock) -> None:
+    def test_dump_xml_failure(self: FFDecInterfaceSpec, mock_subprocess_run: MagicMock) -> None:
         input_swf = Path("./.Patcher-Temp/base.swf")
         output = Path("./folder")
 
@@ -157,7 +157,7 @@ class JPEXSInterfaceSpec (TestCase):
         assert not success
 
     @patch('subprocess.run')
-    def test_rebuild_xml_success(self: JPEXSInterfaceSpec, mock_subprocess_run: MagicMock) -> None:
+    def test_rebuild_xml_success(self: FFDecInterfaceSpec, mock_subprocess_run: MagicMock) -> None:
         input_folder = Path("./.Patcher-Temp/base")
         output = Path("./folder/file.swf")
 
@@ -175,7 +175,7 @@ class JPEXSInterfaceSpec (TestCase):
         assert success
 
     @patch('subprocess.run')
-    def test_rebuild_xml_failure(self: JPEXSInterfaceSpec, mock_subprocess_run: MagicMock) -> None:
+    def test_rebuild_xml_failure(self: FFDecInterfaceSpec, mock_subprocess_run: MagicMock) -> None:
         input_folder = Path("./.Patcher-Temp/base")
         output = Path("./folder/file.swf")
 
@@ -194,7 +194,7 @@ class JPEXSInterfaceSpec (TestCase):
 
     @patch('subprocess.run')
     def test_export_scripts_success(
-        self: JPEXSInterfaceSpec,
+        self: FFDecInterfaceSpec,
         mock_subprocess_run: MagicMock
     ) -> None:
         input_file = Path("base.swf")
@@ -216,7 +216,7 @@ class JPEXSInterfaceSpec (TestCase):
 
     @patch('subprocess.run')
     def test_export_scripts_failure(
-        self: JPEXSInterfaceSpec,
+        self: FFDecInterfaceSpec,
         mock_subprocess_run: MagicMock
     ) -> None:
         input_file = Path("base.swf")
@@ -238,7 +238,7 @@ class JPEXSInterfaceSpec (TestCase):
 
     @patch('subprocess.run')
     def test_recompile_data_success(
-        self: JPEXSInterfaceSpec,
+        self: FFDecInterfaceSpec,
         mock_subprocess_run: MagicMock
     ) -> None:
         input_folder = Path("./.Patcher-Temp/mod")
@@ -261,7 +261,7 @@ class JPEXSInterfaceSpec (TestCase):
 
     @patch('subprocess.run')
     def test_recompile_data_failure(
-        self: JPEXSInterfaceSpec,
+        self: FFDecInterfaceSpec,
         mock_subprocess_run: MagicMock
     ) -> None:
         input_folder = Path("./.Patcher-Temp/mod")

--- a/test/compile/test_ffdec.py
+++ b/test/compile/test_ffdec.py
@@ -49,10 +49,10 @@ class FFDecInterfaceSpec (TestCase):
     @patch('compile.ffdec.FFDecInterface.install_ffdec')
     def test_automatic_installation_complete_failure_not_found(
         self: FFDecInterfaceSpec,
-        mock_install_FFDec: MagicMock
+        mock_install_ffdec: MagicMock
     ) -> None:
 
-        mock_install_FFDec.return_value = False
+        mock_install_ffdec.return_value = False
 
         with raises(ModuleNotFoundError):
             FFDecInterface()

--- a/test/test_patcher.py
+++ b/test/test_patcher.py
@@ -53,8 +53,8 @@ def test_main_success(
     mock_shutil_copytree.assert_called_once_with(cache, Path("./.Patcher-Temp/mod/"))
 
 @patch('compile.compilation.CompilationManager.__init__')
-def test_main_failure_no_jpexs(mock_compilation_manager: MagicMock) -> None:
-    mock_compilation_manager.side_effect = ModuleNotFoundError("no JPEXS")
+def test_main_failure_no_ffdec(mock_compilation_manager: MagicMock) -> None:
+    mock_compilation_manager.side_effect = ModuleNotFoundError("no FFDec")
 
     with raises(DependencyError):
         main(


### PR DESCRIPTION
## Changes
- Rename all instances to JPEXS to FFDec

## Tests
- automated unit tests
- automated integration tests

## Related issues
- closes https://github.com/rayyaw/flash-patcher/issues/51