### PR TITLE
Add PyPI release workflow

### DIFF
--- a/.github/common-setup.sh
+++ b/.github/common-setup.sh
@@ -9,7 +9,7 @@ echo 'export CLASSPATH=".:$GITHUB_WORKSPACE/antlr-4.13.1-complete.jar:$CLASSPATH
 
 echo -e "\nInstalling pip dependencies..."
 python3 -m pip install -U pytest
-python3 -m pip install antlr4-python3-runtime pylint coverage hatch
+python3 -m pip install antlr4-python3-runtime pylint coverage hatch twine
 
 echo -e "\nBuilding ANTLR files..."
 cd build && make antlr-java

--- a/.github/common-setup.sh
+++ b/.github/common-setup.sh
@@ -9,7 +9,7 @@ echo 'export CLASSPATH=".:$GITHUB_WORKSPACE/antlr-4.13.1-complete.jar:$CLASSPATH
 
 echo -e "\nInstalling pip dependencies..."
 python3 -m pip install -U pytest
-python3 -m pip install antlr4-python3-runtime pylint coverage hatch twine
+python3 -m pip install antlr4-python3-runtime pylint coverage hatch
 
 echo -e "\nBuilding ANTLR files..."
 cd build && make antlr-java

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -23,9 +23,10 @@ jobs:
       run: |
         source .github/common-setup.sh
     - name: Install Flash Patcher
+      env:
+        ANTLR_TARGET: antlr-java
       run: |
         cd build
-        export ANTLR_TARGET=antlr-java
         make
         pip install ../dist/*.whl
         cd ..

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -23,7 +23,8 @@ jobs:
       run: |
         source .github/common-setup.sh
     - name: Pylint style analysis
+      env:
+        ANTLR_TARGET: antlr-java
       run: |
-        export ANTLR_TARGET=antlr-java
         cd build
         make pylint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release to PyPI
 # This is explicitly not runnable manually. Manual releases should be initiated locally.
 on: 
   release:
-    types: [published, workflow_dispatch]
+    types: [published, push]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,10 @@ name: Release to PyPI
 # This is explicitly not runnable manually. Manual releases should be initiated locally.
 on: 
   release:
-    types: [published, push]
+    types: [published]
+  push:
+    branches:
+      - pip
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,14 @@ on:
     branches:
       - pip
 
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: pypi-release
+    environment: 
+      name: pypi-release
+      url: https://pypi.org/project/flash-patcher/
+    permissions:
+      id-token: write
     strategy:
       matrix:
         python-version: ["3.11"]
@@ -41,5 +42,4 @@ jobs:
         make
         cd ..
     - name: Release to PyPI
-      run: |
-        twine upload dist/*
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release to PyPI
 # This is explicitly not runnable manually. Manual releases should be initiated locally.
 on: 
   release:
-    types: [published]
+    types: [published, workflow_dispatch]
 
 permissions:
   contents: read
@@ -11,6 +11,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: pypi-release
     strategy:
       matrix:
         python-version: ["3.11"]
@@ -37,8 +38,5 @@ jobs:
         make
         cd ..
     - name: Release to PyPI
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
         twine upload dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,10 @@ name: Release to PyPI
 # This is explicitly not runnable manually. Manual releases should be initiated locally.
 on: 
   release:
-    types: 
-      - published
+    types: [published]
+
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
-name: Unit Tests
+name: Release to PyPI
 
-on: [push, workflow_dispatch]
+# This is explicitly not runnable manually. Manual releases should be initiated locally.
+on: [release]
 
 jobs:
   build:
@@ -22,20 +23,17 @@ jobs:
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh
-    - name: Run unit tests
+    - name: Build Flash Patcher
       env:
         ANTLR_TARGET: antlr-java
       run: |
-        cd build && make test
-    - name: Code Coverage Report
-      uses: irongut/CodeCoverageSummary@v1.3.0
-      with:
-        filename: build/coverage.xml
-        badge: true
-        fail_below_min: true
-        format: markdown
-        hide_branch_rate: false
-        hide_complexity: true
-        indicators: true
-        output: both
-        thresholds: '90 90'
+        export ANTLR_TARGET=antlr-java
+        cd build
+        make
+        cd ..
+    - name: Release to PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        twine upload dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,6 @@ name: Release to PyPI
 on: 
   release:
     types: [published]
-  push:
-    branches:
-      - pip
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
 name: Release to PyPI
 
 # This is explicitly not runnable manually. Manual releases should be initiated locally.
-on: [release]
+on: 
+  release:
+    types: 
+      - published
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ To compile this project yourself, you must install ANTLR. You can view more info
 
 ### Runtime Dependencies
 
-You must install JPEXS Free Flash Decompiler to use this patcher. For more information, check https://github.com/jindrapetrik/jpexs-decompiler.
+You must install JPEXS Free Flash Decompiler to use this patcher. For more information, check https://github.com/jindrapetrik/jpexs-decompiler. You must install this manually.
 
 Flash Patcher will automatically detect your FFDec install location.
 
-You must have Python 3.10 or greater on your system to run this script, including the `antlr4-python3-runtime` pip package.
+You must have Python 3.10 or greater on your system to run this script, including the `antlr4-python3-runtime` pip package. If you install through pip, these will automatically be verified and installed.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ If you want to build the Flash Patcher .whl file locally, run `cd build && make 
 
 If you want to build from source, you should then use `pip` to install the generated wheel file in `dist`,
 
-You can also install Flash Patcher by running `cd build && make && sudo make install`. After this, you can run Flash Patcher with `flash-patcher [args]`.
-
 The command line arguments are as follows:
 
 ### Required arguments

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # Riley's SWF Patcher
 
+### CI/CD
 [![Pylint](https://github.com/rayyaw/flash-patcher/actions/workflows/pylint.yml/badge.svg)](https://github.com/rayyaw/flash-patcher/actions/workflows/pylint.yml)
 [![Unit Tests](https://github.com/rayyaw/flash-patcher/actions/workflows/unittest.yml/badge.svg)](https://github.com/rayyaw/flash-patcher/actions/workflows/unittest.yml)
 [![Integration Tests](https://github.com/rayyaw/flash-patcher/actions/workflows/integrationtest.yml/badge.svg)](https://github.com/rayyaw/flash-patcher/actions/workflows/integrationtest.yml)
+
+### PyPI
+[![PyPI Version](https://img.shields.io/pypi/v/flash-patcher.svg?logo=pypi&label=PyPI&logoColor=gold)](https://pypi.org/project/flash-patcher/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/flash-patcher.svg?logo=python&label=Python&logoColor=gold)](https://pypi.org/project/flash-patcher/)
+
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To apply a patch, run the `flash-patcher` command.
 
 The patcher will take the input SWF, apply the patches specified in the stage file (which must be located in the patch folder), and create the output SWF.
 
-The recommended way to install Flash Patcher is through pip. You can do this via TestPyPI with `pip install -i https://test.pypi.org/simple/ flash-patcher` until we are approved to create an account on the production PyPI environment.
+The recommended way to install Flash Patcher is through pip. You can do this with `pip install flash-patcher`.
 
 If you want to build the Flash Patcher .whl file locally, run `cd build && make wheel`. The .whl will be generated in the dist/ folder. The `hatch` pip package is required to run the build.
 

--- a/build/pyproject.toml
+++ b/build/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "flash-patcher"
 description = "Riley's SWF patcher"
-version = "4.1.10b0"
+version = "4.1.10b1"
 readme = "../README.md"
 license = { file = "../LICENSE" }
 authors = [

--- a/build/pyproject.toml
+++ b/build/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "flash-patcher"
 description = "Riley's SWF patcher"
-version = "4.1.10b1"
+version = "4.1.10"
 readme = "../README.md"
 license = { file = "../LICENSE" }
 authors = [

--- a/build/pyproject.toml
+++ b/build/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "flash-patcher"
 description = "Riley's SWF patcher"
-version = "4.1.10"
+version = "4.1.10b0"
 readme = "../README.md"
 license = { file = "../LICENSE" }
 authors = [


### PR DESCRIPTION
## Changes
- Switch workflows to use environment variables instead of setting them via `export`
- Add a PyPI release workflow

## Testing
- automated tests
- test the workflow by triggering it on a push

## Related issues
- https://github.com/rayyaw/flash-patcher/issues/28 (does not close until we can confirm a full release to PyPI. No additional work is needed other than manually creating the release).