### PR TITLE
Fix bug with multiple injection in the same file

### DIFF
--- a/.github/common-setup.sh
+++ b/.github/common-setup.sh
@@ -1,7 +1,7 @@
 # Common setup for all GitHub workflows of Flash Patcher
 echo -e "\nInstalling FFDec..."
-wget https://github.com/jindrapetrik/jpexs-decompiler/releases/download/version20.0.0/ffdec_20.0.0.deb
-sudo apt install ./ffdec_20.0.0.deb
+wget https://github.com/jindrapetrik/jpexs-decompiler/releases/download/version20.1.0/ffdec_20.1.0.deb
+sudo apt install ./ffdec_20.1.0.deb
 
 echo -e "\nInstalling ANTLR..."
 wget https://www.antlr.org/download/antlr-4.13.1-complete.jar

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The patcher will take the input SWF, apply the patches specified in the stage fi
 
 The recommended way to install Flash Patcher is through pip. You can do this with `pip install flash-patcher`.
 
-If you want to build the Flash Patcher .whl file locally, run `cd build && make wheel`. The .whl will be generated in the dist/ folder. The `hatch` pip package is required to run the build.
+If you want to build the Flash Patcher .whl file locally, run `cd build && make wheel`. The .whl will be generated in the dist/ folder. The `hatch` pip package is required to run the build. You can also run `make install` to install the package locally. **Note that this will run pip with `--break-system-packages` and `--force-reinstall` options, so use this at your own risk.**
 
 If you want to build from source, you should then use `pip` to install the generated wheel file in `dist`,
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ add-asset localfolder/derp.png images/8.png
 
 This asset pack file takes the local file at `localfolder/derp.png` and copies it to `images/8.png` within the SWF. If there was already a file named `images/8.png`, it will be overwritten with the new file.
 
+### Injection Order
+
+Patchfiles and asset packs will be applied in the order that they are specified in the stage file. Within each patchfile, the patches will be processed one block at a time, with each `add` or `remove` being processed from the top of the file to the bottom. Note that if you are injecting multiple times into the same file, this means that you should inject bottom to top to avoid the line numbers changing as the file is being patched.
+
 ## Licensing
 
 This code is made available under CC-BY SA 4.0. For more information, check https://creativecommons.org/licenses/by-sa/4.0 .

--- a/README.md
+++ b/README.md
@@ -35,9 +35,7 @@ The patcher will take the input SWF, apply the patches specified in the stage fi
 
 The recommended way to install Flash Patcher is through pip. You can do this with `pip install flash-patcher`.
 
-If you want to build the Flash Patcher .whl file locally, run `cd build && make wheel`. The .whl will be generated in the dist/ folder. The `hatch` pip package is required to run the build. You can also run `make install` to install the package locally. **Note that this will run pip with `--break-system-packages` and `--force-reinstall` options, so use this at your own risk.**
-
-If you want to build from source, you should then use `pip` to install the generated wheel file in `dist`,
+If you want to build the Flash Patcher .whl file locally, run `cd build && make`. The .whl will be generated in the dist/ folder. The `hatch` pip package is required to run the build. You can also run `make install` to install the package locally. **Note that this will run pip with `--break-system-packages` and `--force-reinstall` options, so use this at your own risk.**
 
 The command line arguments are as follows:
 

--- a/build/Makefile
+++ b/build/Makefile
@@ -2,13 +2,19 @@
 ANTLR_TARGET ?= antlr
 
 # Build the python project using hatch.
-make: $(ANTLR_TARGET)
+all: $(ANTLR_TARGET)
 	rm -rf flash_patcher
 	cp -r ../flash_patcher .
 	find . -type d -exec touch {}/__init__.py \;
 	hatch build
 	cp -r dist ..
 	rm -f ../dist/__init__.py
+
+install: all
+	pip3 install ../dist/*.whl --break-system-packages --force-reinstall
+
+uninstall:
+	pip3 uninstall flash-patcher --break-system-packages
 
 # Move stuff to antlr-source in preparation for compilation
 antlr-copy:

--- a/flash_patcher/inject/single_injection.py
+++ b/flash_patcher/inject/single_injection.py
@@ -38,11 +38,12 @@ class SingleInjectionManager:
         self.patch_line_no = patch_line_no
 
         self.error_manager = ErrorManager(self.patch_file.as_posix(), 0, None)
-        self.file_content = readlines_safe(self.file_name, self.error_manager)
 
     def inject(self: SingleInjectionManager, content: list[str], patch_file_line: int) -> None:
         """Inject the content into the file."""
         patch_line_no = patch_file_line
+
+        self.file_content = readlines_safe(self.file_name, self.error_manager)
         file_line_no = self.file_location.resolve(self.file_content, True, self.error_manager)
 
         if file_line_no is None:

--- a/test/inject/test_single_injection.py
+++ b/test/inject/test_single_injection.py
@@ -56,7 +56,7 @@ class SingleInjectionManagerSpec (TestCase):
 
         # Configure the mock_open.return_value to have a mock for the TextIOWrapper
         mock_open.return_value.__enter__.return_value = mock_file
-        mock_file.readlines.return_value = [" "] * 1000
+        mock_file.readlines.return_value = self.file_content
 
         self.single_injection_manager.file_location = mock_injection_location
         mock_injection_location.resolve.return_value = 2
@@ -68,7 +68,9 @@ class SingleInjectionManagerSpec (TestCase):
             self.file_content.insert(7, "line2\n")
             mock_writelines.assert_called_once_with(self.file_content)
 
-        mock_open.assert_called_once()
+        # .readlines() counts as a mock_open call for some reason
+        assert mock_open.call_count == 2
+
         mock_injection_location.resolve.assert_called_once_with(
             self.file_content, True, self.single_injection_manager.error_manager
         )
@@ -84,14 +86,15 @@ class SingleInjectionManagerSpec (TestCase):
 
         # Configure the mock_open.return_value to have a mock for the TextIOWrapper
         mock_open.return_value.__enter__.return_value = mock_file
-        mock_file.readlines.return_value = [" "] * 1000
+        mock_file.readlines.return_value = self.file_content
 
         with patch.object(mock_file, 'writelines') as mock_writelines:
             self.single_injection_manager.inject(["test\n", "line2\n"], 1)
             self.file_content.extend(["test\n", "line2\n"])
             mock_writelines.assert_called_once_with(self.file_content)
 
-        mock_open.assert_called_once()
+        # .readlines() counts as a mock_open call for some reason
+        assert mock_open.call_count == 2
 
     # Overwriting write is super annoying...
     # (For some reason patching writelines_safe doesn't work)
@@ -104,15 +107,16 @@ class SingleInjectionManagerSpec (TestCase):
 
         # Configure the mock_open.return_value to have a mock for the TextIOWrapper
         mock_open.return_value.__enter__.return_value = mock_file
-        mock_file.readlines.return_value = [" "] * 1000
+        mock_file.readlines.return_value = self.file_content
 
         with patch.object(mock_file, 'writelines') as mock_writelines:
             self.single_injection_manager.inject([], 1)
             mock_writelines.assert_called_once_with(self.file_content)
 
-        mock_open.assert_called_once()
+        # .readlines() counts as a mock_open call for some reason
+        assert mock_open.call_count == 2
 
-        # Overwriting write is super annoying...
+    # Overwriting write is super annoying...
     # (For some reason patching writelines_safe doesn't work)
     @patch('pathlib.Path.open', create=True)
     def test_inject_no_location(
@@ -126,7 +130,7 @@ class SingleInjectionManagerSpec (TestCase):
 
         self.single_injection_manager.inject(["test\n"], 1)
 
-        mock_open.assert_not_called()
+        mock_open.assert_called_once_with()
 
     def test_inject_failure_invalid_command(
         self: SingleInjectionManagerSpec,


### PR DESCRIPTION
## Changes
- Fix a bug with injecting multiple times in the same file, within the same `add` block.
- Update documentation to reflect that this use case is now explicitly stated, and no longer counts as undefined behavior.
- Update the ffdec version in use to one that doesn't have spurious error messages with `ffdec.sh` (we are now using ffdec stable 20.1.0)
- Add install and uninstall targets to the Makefile for easier integration testing.

## Testing
- Verified the change manually with test swf and the provided MROM patch.
- Automated testing.

## Related issues
N/A