### PR TITLE
Improve code coverage checking

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,20 +22,8 @@ jobs:
     - name: Install Common Dependencies
       run: |
         source .github/common-setup.sh
-    - name: Run unit tests
+    - name: Run unit tests and verify coverage
       env:
         ANTLR_TARGET: antlr-java
       run: |
         cd build && make test
-    - name: Code Coverage Report
-      uses: irongut/CodeCoverageSummary@v1.3.0
-      with:
-        filename: build/coverage.xml
-        badge: true
-        fail_below_min: true
-        format: markdown
-        hide_branch_rate: false
-        hide_complexity: true
-        indicators: true
-        output: both
-        thresholds: '95 95'

--- a/build/Makefile
+++ b/build/Makefile
@@ -72,8 +72,7 @@ test: antlr
 
 	@echo "Running tests..."
 	python -m coverage run -m pytest ..
-	python -m coverage report -m $(shell git ls-files "../flash_patcher/*.py")
-	python -m coverage xml -o coverage.xml --omit="../flash_patcher/antlr_source/*"
+	python -m coverage report -m --fail-under=95 $(shell git ls-files "../flash_patcher/*.py")
 
 # Delete all temp files used for compilation.
 # We use find to delete all __init__.py and __pycache__ files and folders


### PR DESCRIPTION
## Changes
- Make the github actions code coverage use the same tool as the local one.
- Remove the extra code coverage step.

## Testing
- Ran locally with a code coverage threshold of 100% to verify that the command would fail.

## Related issues
N/A