### PR TITLE
Add path to python file caller

### DIFF
--- a/flash_patcher/parse/visitor/stage_visitor.py
+++ b/flash_patcher/parse/visitor/stage_visitor.py
@@ -72,7 +72,7 @@ class StagefileProcessor (StagefileVisitor):
         output = output.split(",")
 
         for item in output:
-            self.modified_scripts |= set([Path(item)])
+            self.modified_scripts.add(Path(".Patcher-Temp/mod") / item)
 
     def visitAssetPackFile(
         self: StagefileProcessor,

--- a/test/parse/visitor/test_stage_visitor.py
+++ b/test/parse/visitor/test_stage_visitor.py
@@ -68,8 +68,8 @@ class StagefileProcessorSpec (TestCase):
         self.stage_processor.visitPythonFile(self.python_file_context)
 
         assert self.stage_processor.modified_scripts == set([
-            Path("DoAction1.as"),
-            Path("DoAction2.as")
+            Path(".Patcher-Temp/mod/DoAction1.as"),
+            Path(".Patcher-Temp/mod/DoAction2.as")
         ])
 
     def test_visit_python_file_success_empty(


### PR DESCRIPTION
## Changes
- Calling python files will automatically add the correct path.

## Testing
- Automated testing.

## Related issues
N/A