### PR TITLE
Fix function offset without injection

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -58,7 +58,8 @@ pylint:
 	--disable=missing-class-docstring \
 	--disable=import-error \
 	--disable=wrong-import-position \
-	--disable=no-name-in-module
+	--disable=no-name-in-module \
+	--disable=too-many-public-methods
 
 # Run unit tests
 # The find rule creates an __init__.py in all subdirectories, including nested subdirectories

--- a/build/pyproject.toml
+++ b/build/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "flash-patcher"
 description = "rayyaw's SWF patcher"
-version = "6.1.0"
+version = "6.1.1"
 readme = "../README.md"
 license = { file = "../LICENSE" }
 authors = [

--- a/test/inject/location/test_parser_injection_location.py
+++ b/test/inject/location/test_parser_injection_location.py
@@ -95,6 +95,15 @@ class ParserInjectionLocationSpec (TestCase):
 
         assert line_no == 9
 
+    def test_resolve_success_function_add_after_curly(self: ParserInjectionLocationSpec) -> None:
+        with open("../test/testdata/frame_1/DoAction3.as", encoding="utf-8") as file:
+            file_content = file.readlines()
+
+        line_no = ParserInjectionLocation(self.get_valid_patch_context("function")) \
+            .resolve(file_content, True, self.error_manager)
+
+        assert line_no == 11
+
     def test_resolve_success_function_remove(self: ParserInjectionLocationSpec) -> None:
         line_no = ParserInjectionLocation(self.get_valid_patch_context("function")) \
             .resolve(self.file_content, False, self.error_manager)

--- a/test/testdata/frame_1/DoAction3.as
+++ b/test/testdata/frame_1/DoAction3.as
@@ -1,0 +1,71 @@
+var tile47 = new Object();
+tile47.property = 15;
+tile47.run = function(input) 
+{
+    property = property + input;
+}
+
+
+
+function Mainfunc() 
+{
+    derp;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+// this is a super long file
+// for testing purposes


### PR DESCRIPTION
## Changes
- Fix the function offset without injection. This will now always inject after the next `{` rather than on the line with the `function fn_name()`.

## Testing
- Automated testing.
- Added an extra test to verify this behavior during the case of the `{` not being on the same line as the function header

## Related issues
- n/a