### PR TITLE
Resolve patchfile paths so they can be processed in their parent folder

### DIFF
--- a/flash_patcher/inject/find_content.py
+++ b/flash_patcher/inject/find_content.py
@@ -84,6 +84,9 @@ class FindContentManager:
             )
 
         # If N occurrences are found, get the index of the Nth occurrence
+        # This is defined in all branches of the if/else
+        # except the else which throws an exception
+        #pylint: disable=possibly-used-before-assignment
         if occurrences_found == instance_number:
             split_content = [
                 file_content[:current_index],
@@ -98,6 +101,9 @@ class FindContentManager:
                 """
             )
 
+        # This is defined in the if branch
+        # The else branch throws an exception
+        #pylint: disable=possibly-used-before-assignment
         first_section = split_content[:instance_number]
         second_section = split_content[instance_number:]
 

--- a/flash_patcher/parse/patch_visitor.py
+++ b/flash_patcher/parse/patch_visitor.py
@@ -237,12 +237,13 @@ class PatchfileProcessor (PatchfileParserVisitor):
         # This import needs to happen here, otherwise it would cause a circular dependency
         # pylint: disable=import-outside-toplevel
         from flash_patcher.parse.patch import PatchfileManager
-
+        patch_path = self.folder / ctx_filename
+        patch_folder = patch_path.parent
         self.modified_scripts |= PatchfileManager(
             self.decomp_location,
             self.decomp_location_with_scripts,
-            self.folder / ctx_filename,
-            self.folder,
+            patch_path,
+            patch_folder,
             self.scope,
         ).parse()
 


### PR DESCRIPTION
## Changes
- Changes the patchfile visitor so that it processes patchfiles within their parent directory, rather than in the given root folder.

## Testing
- Automated testing.
- Created a patchfile that loads sub-patches from other places on disk. Those patches use paths relative to themselves. Applying this patchfile works as intended.

## Notes
- This is technically a breaking change, but it's resolving undefined behavior rather than changing defined behavior, and any projects that relied on it should be simple to update.