### PR TITLE
Implement use of a unique logger

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -49,7 +49,8 @@ pylint:
 	--disable=invalid-name \
 	--disable=too-many-arguments \
 	--disable=unspecified-encoding \
-	--disable=import-error
+	--disable=import-error \
+	--disable=import-self
 
 	@echo "Running pylint on tests..."
 	pylint $(shell git ls-files '../test/*.py') \

--- a/flash_patcher/compile/compilation.py
+++ b/flash_patcher/compile/compilation.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 import base64
-from logging import getLogger
 from pathlib import Path
 
 from flash_patcher.compile.ffdec import FFDecInterface
 from flash_patcher.exception.dependency import DependencyError
-
-logger = getLogger(__name__)
+from flash_patcher.util.logging import logger
 
 class CompilationManager:
     """Manage Flash compilation and decompilation, including caching.

--- a/flash_patcher/compile/compilation.py
+++ b/flash_patcher/compile/compilation.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import base64
-from logging import error, info
+from logging import getLogger
 from pathlib import Path
 
 from flash_patcher.compile.ffdec import FFDecInterface
 from flash_patcher.exception.dependency import DependencyError
+
+logger = getLogger(__name__)
 
 class CompilationManager:
     """Manage Flash compilation and decompilation, including caching.
@@ -40,7 +42,7 @@ class CompilationManager:
             failure_mesg = f"""Could not locate the SWF file: {inputfile}.
             Aborting..."""
 
-            error(failure_mesg)
+            logger.error(failure_mesg)
             raise FileNotFoundError(failure_mesg)
 
         # Decompile swf into temp folder called ./.Patcher-Temp/[swf name, base32 encoded]
@@ -56,13 +58,13 @@ class CompilationManager:
             if not Path(cache_location).exists() and not xml_mode:
                 Path(cache_location).mkdir()
 
-            info("Beginning decompilation...")
+            logger.info("Beginning decompilation...")
 
             decomp = None
 
             if xml_mode:
                 decomp = self.decompiler.dump_xml(inputfile, cache_location)
-                info("XML decompilation mode.")
+                logger.info("XML decompilation mode.")
             else:
                 decomp = self.decompiler.export_scripts(inputfile, cache_location)
 
@@ -70,11 +72,11 @@ class CompilationManager:
                 failure_mesg = f"""FFDec couldn't decompile the SWF file: {inputfile}.
                     Aborting..."""
 
-                error(failure_mesg)
+                logger.error(failure_mesg)
                 raise DependencyError(failure_mesg)
 
         else:
-            info("Detected cached decompilation. Skipping...")
+            logger.info("Detected cached decompilation. Skipping...")
 
         return cache_location
 
@@ -92,7 +94,7 @@ class CompilationManager:
             failure_mesg = f"""FFDec couldn't recompile the SWF file: {swf}.
                 Aborting.."""
 
-            error(failure_mesg)
+            logger.error(failure_mesg)
             raise DependencyError(failure_mesg)
 
     def recompile(

--- a/flash_patcher/compile/ffdec.py
+++ b/flash_patcher/compile/ffdec.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import os
 import subprocess
-from logging import getLogger
 from pathlib import Path
+
+from flash_patcher.util.logging import logger
 
 LOCATION_APT = Path("/usr/bin/ffdec")
 LOCATION_FLATPAK = Path("/usr/bin/flatpak")
@@ -17,8 +18,6 @@ ARGS_FLATPAK = [
     "--command=ffdec.sh",
     "com.jpexs.decompiler.flash",
 ]
-
-logger = getLogger(__name__)
 
 class FFDecInterface:
     """An interface to interact with FFDec via the shell.

--- a/flash_patcher/compile/ffdec.py
+++ b/flash_patcher/compile/ffdec.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
-from logging import info
+from logging import getLogger
 from pathlib import Path
 
 LOCATION_APT = Path("/usr/bin/ffdec")
@@ -17,6 +17,8 @@ ARGS_FLATPAK = [
     "--command=ffdec.sh",
     "com.jpexs.decompiler.flash",
 ]
+
+logger = getLogger(__name__)
 
 class FFDecInterface:
     """An interface to interact with FFDec via the shell.
@@ -42,7 +44,7 @@ class FFDecInterface:
             else:
                 self.args = args
 
-            info("Using FFDec at: %s", path)
+            logger.info("Using FFDec at: %s", path)
 
         else:
             # Auto-detect FFDec at any of the default locations
@@ -61,7 +63,7 @@ class FFDecInterface:
                     """
                 )
 
-            info("Using FFDec at: %s", self.path)
+            logger.info("Using FFDec at: %s", self.path)
 
     def install_ffdec(self: FFDecInterface, path: Path, args: list[str] | None = None) -> bool:
         """Install FFDec from a path. Return true if the installation was successful."""
@@ -131,7 +133,7 @@ class FFDecInterface:
         
         Returns True on success.
         """
-        info("Exporting scripts into %s...", output_dir)
+        logger.info("Exporting scripts into %s...", output_dir)
 
         # set check=False, we will verify the return code manually later
         process = subprocess.run(
@@ -160,7 +162,7 @@ class FFDecInterface:
         """Recompile data of a given type into the SWF file."""
 
         # Part types: SymbolClass, Movies, Sounds, Shapes, Images, Text, Script
-        info("Reimporting %s...", part)
+        logger.info("Reimporting %s...", part)
 
         # set check=False, we will verify the return code manually later
         process = subprocess.run(

--- a/flash_patcher/exception/error_manager.py
+++ b/flash_patcher/exception/error_manager.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from logging import error
-
 from flash_patcher.exception.injection import InjectionError
+from flash_patcher.util.logging import logger
 
 class ErrorManager:
     """Handle exceptions thrown by Flash Patcher during the injection stage."""
@@ -33,5 +32,5 @@ class ErrorManager:
             {mesg}
             Aborting..."""
 
-        error(error_mesg)
+        logger.error(error_mesg)
         raise exc_type(mesg)

--- a/flash_patcher/exception/error_suppression.py
+++ b/flash_patcher/exception/error_suppression.py
@@ -1,9 +1,9 @@
 import io
 import sys
-from logging import error
 from typing import Callable
 
 from flash_patcher.exception.dependency import DependencyError
+from flash_patcher.util.logging import logger
 
 def run_without_antlr_errors(function: Callable[..., any]) -> any:
     """Run a command while suppressing ANTLR version mismatch warnings.
@@ -35,5 +35,5 @@ def process_captured_output(captured_output = str) -> None:
     if captured_output != "":
         error_mesg = f"""Processing halted due to lex and parse errors.
             More info:\n{captured_output}"""
-        error(error_mesg)
+        logger.error(error_mesg)
         raise DependencyError(error_mesg)

--- a/flash_patcher/parse/common.py
+++ b/flash_patcher/parse/common.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from logging import getLogger
 from pathlib import Path
 from typing import Type
 
@@ -12,8 +11,7 @@ from flash_patcher.exception.dependency import DependencyError
 from flash_patcher.exception.error_suppression import run_without_antlr_errors
 from flash_patcher.exception.error_manager import ErrorManager
 from flash_patcher.util.file_io import read_safe
-
-logger = getLogger(__name__)
+from flash_patcher.util.logging import logger
 
 class CommonParseManager:
     """Common logic for parsing any file type."""

--- a/flash_patcher/parse/common.py
+++ b/flash_patcher/parse/common.py
@@ -71,4 +71,3 @@ class CommonParseManager:
             raise DependencyError(error_mesg) from exc
 
         return tree
-        

--- a/flash_patcher/parse/common.py
+++ b/flash_patcher/parse/common.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from logging import exception, info
+from logging import getLogger
 from pathlib import Path
 from typing import Type
 
@@ -12,6 +12,8 @@ from flash_patcher.exception.dependency import DependencyError
 from flash_patcher.exception.error_suppression import run_without_antlr_errors
 from flash_patcher.exception.error_manager import ErrorManager
 from flash_patcher.util.file_io import read_safe
+
+logger = getLogger(__name__)
 
 class CommonParseManager:
     """Common logic for parsing any file type."""
@@ -47,7 +49,7 @@ class CommonParseManager:
         This will automatically process all errors.
         Note that the syntax tree root within your grammar MUST have the name `root`.
         """
-        info("Processing file: %s", file.as_posix())
+        logger.info("Processing file: %s", file.as_posix())
         error_manager = ErrorManager(file.as_posix(), 0)
         file_content = read_safe(file, error_manager)
 
@@ -65,7 +67,7 @@ class CommonParseManager:
             There is likely additional logging output above.
             """
 
-            exception(error_mesg)
+            logger.exception(error_mesg)
             raise DependencyError(error_mesg) from exc
 
         return tree

--- a/flash_patcher/parse/patch_visitor.py
+++ b/flash_patcher/parse/patch_visitor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import shutil
-from logging import exception
 from pathlib import Path
 
 from flash_patcher.antlr_source.PatchfileParser import PatchfileParser
@@ -15,6 +14,7 @@ from flash_patcher.inject.single_injection import SingleInjectionManager
 from flash_patcher.parse.scope import Scope
 from flash_patcher.util.external_cmd import get_modified_scripts_of_command
 from flash_patcher.util.file_io import FileWritebackManager, read_safe, writelines_safe
+from flash_patcher.util.logging import logger
 
 class PatchfileProcessor (PatchfileParserVisitor):
     """This class inherits from the ANTLR visitor to process patch files.
@@ -102,7 +102,7 @@ class PatchfileProcessor (PatchfileParserVisitor):
         if not Path(self.folder / local_name).exists():
             error_mesg = f"""Could not find asset: {local_name}
             Aborting..."""
-            exception(error_mesg)
+            logger.exception(error_mesg)
             raise FileNotFoundError(error_mesg)
 
         # Create folder and copy things over

--- a/flash_patcher/patcher.py
+++ b/flash_patcher/patcher.py
@@ -39,7 +39,7 @@ def print_version() -> None:
     except PackageNotFoundError:
         __version__ = "Unit Tests"
 
-    logger.info(f"rayyaw's SWF Patcher - v%s", __version__)
+    logger.info("rayyaw's SWF Patcher - v%s", __version__)
 
 def main(
     inputfile: Path,

--- a/flash_patcher/patcher.py
+++ b/flash_patcher/patcher.py
@@ -1,4 +1,3 @@
-import logging
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
@@ -7,6 +6,7 @@ from flash_patcher.compile.locate_decomp import get_decomp_locations
 from flash_patcher.exception.dependency import DependencyError
 from flash_patcher.parse.patch import PatchfileManager
 from flash_patcher.util.file_copy import clean_scripts, copy_file
+from flash_patcher.util.logging import logger
 
 # pylint: disable=pointless-string-statement
 """
@@ -24,13 +24,6 @@ Dependencies: Python 3, JPEXS Decompiler (https://github.com/jindrapetrik/jpexs-
 Inject arbitrary code, images, and more into existing SWFs!
 See the README for documentation and license.
 """
-
-formatter = logging.Formatter("%(levelname)s: %(message)s")
-handler = logging.StreamHandler()
-handler.setFormatter(formatter)
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-logger.addHandler(handler)
 
 def print_version() -> None:
     """Print the Flash Patcher version."""

--- a/flash_patcher/patcher.py
+++ b/flash_patcher/patcher.py
@@ -6,7 +6,7 @@ from flash_patcher.compile.locate_decomp import get_decomp_locations
 from flash_patcher.exception.dependency import DependencyError
 from flash_patcher.parse.patch import PatchfileManager
 from flash_patcher.util.file_copy import clean_scripts, copy_file
-from flash_patcher.util.logging import logger, logger_setup
+from flash_patcher.util.logging import logger
 
 # pylint: disable=pointless-string-statement
 """
@@ -44,7 +44,6 @@ def main(
     xml_mode: bool = False,
 ) -> None:
     """Run the patcher."""
-    logger_setup()
     print_version()
 
     try:

--- a/flash_patcher/patcher.py
+++ b/flash_patcher/patcher.py
@@ -39,7 +39,7 @@ def print_version() -> None:
     except PackageNotFoundError:
         __version__ = "Unit Tests"
 
-    logger.info(f"rayyaw's SWF Patcher - v{__version__}")
+    logger.info(f"rayyaw's SWF Patcher - v%s", __version__)
 
 def main(
     inputfile: Path,

--- a/flash_patcher/patcher.py
+++ b/flash_patcher/patcher.py
@@ -1,4 +1,4 @@
-from logging import basicConfig, exception, info
+import logging
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
@@ -25,7 +25,12 @@ Inject arbitrary code, images, and more into existing SWFs!
 See the README for documentation and license.
 """
 
-basicConfig(level=1, format="%(levelname)s: %(message)s")
+formatter = logging.Formatter("%(levelname)s: %(message)s")
+handler = logging.StreamHandler()
+handler.setFormatter(formatter)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.addHandler(handler)
 
 def print_version() -> None:
     """Print the Flash Patcher version."""
@@ -34,7 +39,7 @@ def print_version() -> None:
     except PackageNotFoundError:
         __version__ = "Unit Tests"
 
-    info(f"rayyaw's SWF Patcher - v{__version__}")
+    logger.info(f"rayyaw's SWF Patcher - v{__version__}")
 
 def main(
     inputfile: Path,
@@ -52,7 +57,7 @@ def main(
         compiler = CompilationManager()
     except ModuleNotFoundError as exc:
         error_mesg = "Could not locate required dependency: JPEXS Flash Decompiler. Aborting..."
-        exception(error_mesg)
+        logger.exception(error_mesg)
         raise DependencyError(error_mesg) from exc
 
     decomp_location, decomp_location_with_scripts = get_decomp_locations(xml_mode)
@@ -66,7 +71,7 @@ def main(
     # Copy the cache to a different location so we can reuse it
     copy_file(cache_location, decomp_location)
 
-    info("Decompilation finished. Beginning injection...")
+    logger.info("Decompilation finished. Beginning injection...")
 
     modified_scripts = PatchfileManager(
         decomp_location,
@@ -75,11 +80,11 @@ def main(
         folder,
     ).parse()
 
-    info("Injection complete, cleaning up...")
+    logger.info("Injection complete, cleaning up...")
 
     clean_scripts(decomp_location, modified_scripts)
 
-    info("Recompiling...")
+    logger.info("Recompiling...")
 
     compiler.recompile(
         decomp_location,
@@ -89,4 +94,4 @@ def main(
         xml_mode=xml_mode,
     )
 
-    info("Done.")
+    logger.info("Done.")

--- a/flash_patcher/patcher.py
+++ b/flash_patcher/patcher.py
@@ -6,7 +6,7 @@ from flash_patcher.compile.locate_decomp import get_decomp_locations
 from flash_patcher.exception.dependency import DependencyError
 from flash_patcher.parse.patch import PatchfileManager
 from flash_patcher.util.file_copy import clean_scripts, copy_file
-from flash_patcher.util.logging import logger
+from flash_patcher.util.logging import logger, logger_setup
 
 # pylint: disable=pointless-string-statement
 """
@@ -44,6 +44,7 @@ def main(
     xml_mode: bool = False,
 ) -> None:
     """Run the patcher."""
+    logger_setup()
     print_version()
 
     try:

--- a/flash_patcher/util/file_io.py
+++ b/flash_patcher/util/file_io.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from logging import exception
 from pathlib import Path
 from typing import Any, Optional, Type
 
 from flash_patcher.exception.error_manager import ErrorManager
+from flash_patcher.util.logging import logger
 
 class FileWritebackManager:
     """Handle files. Will open and read the content, and writeback when the file is closed."""
@@ -87,5 +87,5 @@ def writelines_safe(path: Path, lines: list[str]) -> None:
     except (FileNotFoundError, IsADirectoryError) as exc:
         mesg = """The provided decompilation is not in a writable location.
             Please ensure you have write access in the current directory."""
-        exception(mesg)
+        logger.exception(mesg)
         raise exc

--- a/flash_patcher/util/logging.py
+++ b/flash_patcher/util/logging.py
@@ -1,10 +1,19 @@
-from logging import Formatter, StreamHandler, getLogger, INFO
+from logging import Formatter, StreamHandler, getLogger, INFO, Logger
 
-logger = getLogger(__name__)
+logger: Logger = None
 
-def logger_setup():
+def _logger_setup() -> Logger:
+    """Sets up the main logger for use."""
+    if logger is not None:
+        logger.warning("Logger is already initialized.")
+        return
+
     formatter = Formatter("%(levelname)s: %(message)s")
     handler = StreamHandler()
     handler.setFormatter(formatter)
-    logger.setLevel(INFO)
-    logger.addHandler(handler)
+    new_logger = getLogger(__name__)
+    new_logger.setLevel(INFO)
+    new_logger.addHandler(handler)
+    return new_logger
+
+logger = _logger_setup()

--- a/flash_patcher/util/logging.py
+++ b/flash_patcher/util/logging.py
@@ -1,8 +1,10 @@
 from logging import Formatter, StreamHandler, getLogger, INFO
 
-formatter = Formatter("%(levelname)s: %(message)s")
-handler = StreamHandler()
-handler.setFormatter(formatter)
 logger = getLogger(__name__)
-logger.setLevel(INFO)
-logger.addHandler(handler)
+
+def logger_setup():
+    formatter = Formatter("%(levelname)s: %(message)s")
+    handler = StreamHandler()
+    handler.setFormatter(formatter)
+    logger.setLevel(INFO)
+    logger.addHandler(handler)

--- a/flash_patcher/util/logging.py
+++ b/flash_patcher/util/logging.py
@@ -1,0 +1,8 @@
+from logging import Formatter, StreamHandler, getLogger, INFO
+
+formatter = Formatter("%(levelname)s: %(message)s")
+handler = StreamHandler()
+handler.setFormatter(formatter)
+logger = getLogger(__name__)
+logger.setLevel(INFO)
+logger.addHandler(handler)


### PR DESCRIPTION
## Changes
- Replaces the `basicConfig()` setup with a unique `getLogger()` setup, avoiding pollution of the root logger. See [this blog post](https://rednafi.com/python/no_hijack_root_logger/) for an explanation of why this is important.

## Testing
- Automated testing.
- Tested with the Flapman GUI. Was able to properly redirect output into a custom handler.