### PR TITLE
Add verbose logging option

### DIFF
--- a/build/pyproject.toml
+++ b/build/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "flash-patcher"
 description = "rayyaw's SWF patcher"
-version = "6.2.1"
+version = "6.2.2"
 readme = "../README.md"
 license = { file = "../LICENSE" }
 authors = [

--- a/flash_patcher/__main__.py
+++ b/flash_patcher/__main__.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
 
-import argparse
+from argparse import ArgumentParser, Namespace
 from pathlib import Path
 
 from flash_patcher.patcher import main, print_version
 
+def validate_args(args: Namespace) -> bool:
+    """Validate if all CLI arguments are provided correctly."""
+    return args.input_swf and args.folder and args.stagefile and args.output_swf
+
 def cli() -> None:
     """Run Flash Patcher from the CLI."""
-    parser = argparse.ArgumentParser()
+    parser = ArgumentParser()
 
     parser.add_argument(
         "--inputswf",
@@ -69,16 +73,24 @@ def cli() -> None:
         help="Print the current version of Flash Patcher and exit",
     )
 
+    parser.add_argument(
+        "--verbose",
+        dest="verbose",
+        default=False,
+        action="store_true",
+        help="Show verbose logging output",
+    )
+
     args = parser.parse_args()
 
     if args.version:
         print_version()
         return
 
-    if (not args.input_swf) or (not args.folder) or (not args.stagefile) or (not args.output_swf):
+    if not validate_args(args):
         parser.print_usage()
         print("flash-patcher: error: the following arguments are required:\n \
-              --inputswf, --folder, --stagefile, --outputswf")
+            --inputswf, --folder, --stagefile, --outputswf")
         return
 
     main(
@@ -89,6 +101,7 @@ def cli() -> None:
         drop_cache=args.drop_cache,
         recompile_all=args.recompile_all,
         xml_mode=args.xml_mode,
+        verbose=args.verbose,
     )
 
 

--- a/flash_patcher/__main__.py
+++ b/flash_patcher/__main__.py
@@ -6,7 +6,9 @@ from pathlib import Path
 from flash_patcher.patcher import main, print_version
 
 def validate_args(args: Namespace) -> bool:
-    """Validate if all CLI arguments are provided correctly."""
+    """Validate if all CLI arguments are provided correctly.
+    Returns True if the provided set of arguments is valid.
+    """
     return args.input_swf and args.folder and args.stagefile and args.output_swf
 
 def cli() -> None:

--- a/flash_patcher/patcher.py
+++ b/flash_patcher/patcher.py
@@ -1,4 +1,5 @@
 from importlib.metadata import PackageNotFoundError, version
+# pylint: disable=no-name-in-module
 from logging import DEBUG
 from pathlib import Path
 

--- a/flash_patcher/patcher.py
+++ b/flash_patcher/patcher.py
@@ -1,4 +1,5 @@
 from importlib.metadata import PackageNotFoundError, version
+from logging import DEBUG
 from pathlib import Path
 
 from flash_patcher.compile.compilation import CompilationManager
@@ -42,8 +43,12 @@ def main(
     drop_cache: bool = False,
     recompile_all: bool = False,
     xml_mode: bool = False,
+    verbose: bool = False,
 ) -> None:
     """Run the patcher."""
+    if verbose:
+        logger.setLevel(DEBUG)
+
     print_version()
 
     try:

--- a/test/inject/test_single_injection.py
+++ b/test/inject/test_single_injection.py
@@ -188,3 +188,4 @@ class SingleInjectionManagerSpec (TestCase):
             self.single_injection_manager.handle_secondary_skip_command(
                 1, "// cmd: skip 3.2"
             )
+    

--- a/test/inject/test_single_injection.py
+++ b/test/inject/test_single_injection.py
@@ -188,4 +188,3 @@ class SingleInjectionManagerSpec (TestCase):
             self.single_injection_manager.handle_secondary_skip_command(
                 1, "// cmd: skip 3.2"
             )
-    


### PR DESCRIPTION
## Changes
- Add verbose logging option.
- Refactor valid command line arguments into its own function.
- 6.2.1 -> 6.2.2

## Testing
- Automated testing.
- Added a debug log and verified it was printed with the `--verbose` flag.
- Added a debug log and verified it was not printed when the `--verbose` flag was not present.
- Made sure the valid command line arguments allowed the program to run.
- Made sure an invalid set of command line arguments caused the program to early exit.

## Related issues
- closes https://github.com/rayyaw/flash-patcher/issues/89