### PR TITLE
Implement quoted strings for file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,12 +152,10 @@ An `add-asset` command will look something like this:
 
 ```
 # Comment
-add-asset localfolder/derp.png images/8.png
+add-asset "localfolder/derp.png" "images/8.png"
 ```
 
 This command takes the local file at `localfolder/derp.png` and copies it to `images/8.png` within the SWF. If there was already a file named `images/8.png`, it will be overwritten with the new file.
-
-**Note:** Due to technical reasons, neither filepath in the `add-asset` command may contain spaces, dashes (`-`), or the equals sign (`=`).
 
 ### Variables and scoping
 
@@ -177,7 +175,7 @@ Note that all blocks where arbitrary text is allowed (ie, not specific formats l
 
 Nested variable definitions are not allowed. For example, `set var1=${var2}` will set the value of `var1` to the **string literal** `${var2}` rather than the value of `var2`.
 
-**Note:** Due to technical reasons, variable names and values may not contain dashes (`-`) or the equals sign (`=`).
+**Note:** Due to technical limitations, variable names and values may not contain dashes (`-`) or the equals sign (`=`).
 
 
 ### Content Insertion
@@ -202,14 +200,18 @@ To inject while in XML mode, use normal `.patch` files, but the add location wil
 You can apply arbitrary patch files within the main file. These can be executed as follows:
 
 ```
-apply-patch file.patch
+apply-patch "file.patch"
 ```
 
 ### Python Files
 
 Arbitrary Python scripts can be referenced in the patch file. They should be placed in the patch folder, and will be executed inside the decompiled directory.
 
-The command looks like this: `exec-python file.py`.
+The command looks like this:
+
+```
+exec-python "file.py"
+```
 
 You must respect the following API:
 

--- a/README.md
+++ b/README.md
@@ -152,10 +152,12 @@ An `add-asset` command will look something like this:
 
 ```
 # Comment
-add-asset "localfolder/derp.png" "images/8.png"
+add-asset localfolder/derp.png images/8.png
 ```
 
 This command takes the local file at `localfolder/derp.png` and copies it to `images/8.png` within the SWF. If there was already a file named `images/8.png`, it will be overwritten with the new file.
+
+**Note:** Due to technical limitations, file paths that contain dashes (`-`) or spaces (` `) must be surrounded with quotes. See the section "Quoted Strings" for further info.
 
 ### Variables and scoping
 
@@ -200,7 +202,7 @@ To inject while in XML mode, use normal `.patch` files, but the add location wil
 You can apply arbitrary patch files within the main file. These can be executed as follows:
 
 ```
-apply-patch "file.patch"
+apply-patch file.patch
 ```
 
 ### Python Files
@@ -210,7 +212,7 @@ Arbitrary Python scripts can be referenced in the patch file. They should be pla
 The command looks like this:
 
 ```
-exec-python "file.py"
+exec-python file.py
 ```
 
 You must respect the following API:
@@ -236,6 +238,15 @@ Note that a trailing newline may be present. Also note that both variable names 
 ### Injection Order
 
 Within each patchfile, the patches will be processed one block at a time, with each command being processed from the top of the file to the bottom. Note that if you are injecting multiple times into the same file, this means that you should inject bottom to top to avoid the line numbers changing as the file is being patched.
+
+### Quoted Strings
+
+Ordinarily, file paths containing dashes (`-`) and spaces (` `) are not allowed in file paths, as they will cause parsing issues. However, if these characters are required, the issue can be solved by surrounding the file path in quote marks, like so:
+
+```
+apply-patch "illegal-file-name.patch"
+apply-patch "illegal file name.patch"
+```
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ add-asset localfolder/derp.png images/8.png
 
 This command takes the local file at `localfolder/derp.png` and copies it to `images/8.png` within the SWF. If there was already a file named `images/8.png`, it will be overwritten with the new file.
 
-**Note:** Due to technical limitations, file paths that contain dashes (`-`) or spaces (` `) must be surrounded with quotes. See the section "Quoted Strings" for further info.
+**Note:** Due to technical limitations, file paths that contain dashes (`-`), spaces (` `), or equals signs ('=') must be surrounded with quotes. See the section "Quoted Strings" for further info.
 
 ### Variables and scoping
 
@@ -241,7 +241,7 @@ Within each patchfile, the patches will be processed one block at a time, with e
 
 ### Quoted Strings
 
-Ordinarily, file paths containing dashes (`-`) and spaces (` `) are not allowed in file paths, as they will cause parsing issues. However, if these characters are required, the issue can be solved by surrounding the file path in quote marks, like so:
+Ordinarily, file paths containing dashes (`-`), spaces (` `), or equals signs ('=') are not allowed in file paths, as they will cause parsing issues. However, if these characters are required, the issue can be solved by surrounding the file path in quote marks, like so:
 
 ```
 apply-patch "illegal-file-name.patch"

--- a/build/Makefile
+++ b/build/Makefile
@@ -50,7 +50,8 @@ pylint:
 	--disable=too-many-arguments \
 	--disable=unspecified-encoding \
 	--disable=import-error \
-	--disable=import-self
+	--disable=import-self \
+	--disable=too-many-positional-arguments
 
 	@echo "Running pylint on tests..."
 	pylint $(shell git ls-files '../test/*.py') \

--- a/flash_patcher/antlr/PatchfileLexer.g4
+++ b/flash_patcher/antlr/PatchfileLexer.g4
@@ -63,8 +63,9 @@ INTEGER : NUMBER+;
 DASH    : '-';
 PLUS    : '+';
 EQUALS  : '=';
+QUOTE   : '"' -> skip, mode(QUOTE_MODE);
 
-TEXT_BLOCK  : ~( '-' | '=' | ' ' | '\r' | '\n')+;
+TEXT_BLOCK  : ~( '"' | '-' | '=' | ' ' | '\r' | '\n')+;
 
 // Stuff to ignore, like comments or whitespace
 WHITESPACE  : [ \t\r\n\f]+         -> skip;
@@ -77,3 +78,7 @@ AS_TEXT     : .+?;
 mode CONTENT_MODE;
 END_CONTENT : E N D '-' C O N T E N T -> mode(DEFAULT_MODE);
 CONTENT_TEXT: .+?;
+
+mode QUOTE_MODE;
+END_QUOTE   : QUOTE -> skip, mode(DEFAULT_MODE);
+QUOTED_TEXT : ~( '"' | '\r' | '\n')+;

--- a/flash_patcher/antlr/PatchfileParser.g4
+++ b/flash_patcher/antlr/PatchfileParser.g4
@@ -17,8 +17,9 @@ replaceAllBlockHeader   : REPLACE_ALL FILENAME;
 replaceAllBlock         : replaceAllBlockHeader+ BEGIN_CONTENT replaceBlockText END_CONTENT BEGIN_PATCH addBlockText END_PATCH;
 replaceBlockText        : CONTENT_TEXT+;
 
-setVarBlock             : SET_VAR var_name=TEXT_BLOCK EQUALS var_value=(TEXT_BLOCK | INTEGER);
-exportVarBlock          : EXPORT_VAR var_name=TEXT_BLOCK EQUALS var_value=(TEXT_BLOCK | INTEGER);
+varValue                : TEXT_BLOCK | QUOTED_TEXT | INTEGER;
+setVarBlock             : SET_VAR var_name=TEXT_BLOCK EQUALS varValue;
+exportVarBlock          : EXPORT_VAR var_name=TEXT_BLOCK EQUALS varValue;
 
 execPatcherBlock        : EXEC_PATCHER file_name;
 execPythonBlock         : EXEC_PYTHON file_name;

--- a/flash_patcher/antlr/PatchfileParser.g4
+++ b/flash_patcher/antlr/PatchfileParser.g4
@@ -43,4 +43,4 @@ locationToken           : OPEN_BLOCK? FUNCTION TEXT_BLOCK INTEGER? CLOSE_BLOCK? 
                         | END                                                           # end
                         ;
 
-file_name               : TEXT_BLOCK;
+file_name               : TEXT_BLOCK | QUOTED_TEXT;

--- a/flash_patcher/parse/patch_visitor.py
+++ b/flash_patcher/parse/patch_visitor.py
@@ -217,14 +217,14 @@ class PatchfileProcessor (PatchfileParserVisitor):
         ctx: PatchfileParser.SetVarBlockContext
     ) -> None:
         """Define a locally (downward-scoped only) variable."""
-        self.scope.define_local(ctx.var_name.text, ctx.var_value.text)
+        self.scope.define_local(ctx.var_name.text, ctx.varValue().getText())
 
     def visitExportVarBlock(
         self: PatchfileProcessor,
         ctx: PatchfileParser.ExportVarBlockContext
     ) -> None:
         """Define a global variable."""
-        self.scope.define_global(ctx.var_name.text, ctx.var_value.text)
+        self.scope.define_global(ctx.var_name.text, ctx.varValue().getText())
 
     def visitExecPatcherBlock(
         self: PatchfileProcessor,

--- a/test/parse/test_patch_visitor.py
+++ b/test/parse/test_patch_visitor.py
@@ -171,19 +171,25 @@ class PatchfileProcessorSpec (TestCase):
             Path("../test/testdata/Pack1.assets")
         )
 
-        mock_path_exists.side_effect = [True, False]
+        mock_path_exists.side_effect = [True, False, True, False]
 
         self.patch_visitor.visitRoot(root_context)
 
-        mock_path_mkdir.assert_called_once_with(
-            Path(".Patcher-Temp/images")
-        )
-        mock_shutil_copyfile.assert_called_once_with(
+        assert mock_path_mkdir.call_count == 2
+        assert mock_path_mkdir.call_args_list[0].args == (Path(".Patcher-Temp/images"),)
+        assert mock_path_mkdir.call_args_list[1].args == (Path(".Patcher-Temp/images"),)
+
+        assert mock_shutil_copyfile.call_count == 2
+        assert mock_shutil_copyfile.call_args_list[0].args == (
             Path("../test/testdata/local.png"), Path(".Patcher-Temp/images/18.png")
+        )
+        assert mock_shutil_copyfile.call_args_list[1].args == (
+            Path("../test/testdata/space -dash.png"), Path(".Patcher-Temp/images/space -dash.png")
         )
 
         assert self.patch_visitor.modified_scripts == set([
-            Path(".Patcher-Temp/images/18.png")
+            Path(".Patcher-Temp/images/18.png"),
+            Path(".Patcher-Temp/images/space -dash.png")
         ])
 
     @patch('shutil.copyfile')
@@ -201,12 +207,17 @@ class PatchfileProcessorSpec (TestCase):
 
         self.patch_visitor.visitRoot(root_context)
 
-        mock_shutil_copyfile.assert_called_once_with(
+        assert mock_shutil_copyfile.call_count == 2
+        assert mock_shutil_copyfile.call_args_list[0].args == (
             Path("../test/testdata/local.png"), Path(".Patcher-Temp/images/18.png")
+        )
+        assert mock_shutil_copyfile.call_args_list[1].args == (
+            Path("../test/testdata/space -dash.png"), Path(".Patcher-Temp/images/space -dash.png")
         )
 
         assert self.patch_visitor.modified_scripts == set([
-            Path(".Patcher-Temp/images/18.png")
+            Path(".Patcher-Temp/images/18.png"),
+            Path(".Patcher-Temp/images/space -dash.png")
         ])
 
     @patch('pathlib.Path.exists')
@@ -285,7 +296,6 @@ class PatchfileProcessorSpec (TestCase):
         self.patch_visitor.visitExecPatcherBlock(patchfile_context)
 
         mock_parse_patchfile.assert_called_once_with()
-
 
     @patch('flash_patcher.parse.patch_visitor.PatchfileProcessor.visitRemoveBlock')
     @patch('flash_patcher.parse.patch_visitor.PatchfileProcessor.visitAddBlock')

--- a/test/testdata/Pack1.assets
+++ b/test/testdata/Pack1.assets
@@ -1,3 +1,4 @@
 add-asset local.png images/18.png
+add-asset "space -dash.png" "images/space -dash.png"
 
 # comment


### PR DESCRIPTION
## Changes
- Implemented `QUOTE_MODE`, triggered and ended by the `QUOTE` token, with any other text between considerd as a `QUOTED_TEXT` token.
- Updated README.md accordingly.

## Testing
- Automated testing.
- Tested a patch containing `apply-patch "~/Documents/test-mod/mod.patch"`
- Tested a patch containing `apply-patch "~/Documents/test mod/mod.patch"`

## Related issues
- Fixes an issue causing file paths that contain dashes or spaces to be cut off at the offending character.